### PR TITLE
Committees positions backend

### DIFF
--- a/backend/migrator/src/migrator.js
+++ b/backend/migrator/src/migrator.js
@@ -1,13 +1,13 @@
-const { database } = require('dsek-shared');
+const { knex } = require('dsek-shared');
 
 const migrate = async () => {
   for (i = 0; i < 10; i++) {
     const timeout = i * 500;
     await new Promise(resolve => setTimeout(resolve, timeout));
     try {
-      const pastVersion = await database.migrate.currentVersion();
-      await database.migrate.latest();
-      const newVersion = await database.migrate.currentVersion();
+      const pastVersion = await knex.migrate.currentVersion();
+      await knex.migrate.latest();
+      const newVersion = await knex.migrate.currentVersion();
       console.log('Migration successful')
       if (pastVersion === newVersion) console.log('Already latest version')
       else console.log(`migrated from ${pastVersion} to ${newVersion}`)
@@ -22,7 +22,7 @@ const migrate = async () => {
 
 const seed = async () => {
   try {
-    const [ seeds ] = await database.seed.run();
+    const [ seeds ] = await knex.seed.run();
     console.log('Seed successful')
     console.log('Seeds applied:')
     seeds.forEach(s => console.log(`\t${s}`))

--- a/backend/services/members/src/db.ts
+++ b/backend/services/members/src/db.ts
@@ -1,4 +1,5 @@
-import { database as knex } from 'dsek-shared';
+import { ForbiddenError } from 'apollo-server';
+import { context, knex, dbUtils } from 'dsek-shared';
 
 interface DbMember {
   id: number,
@@ -9,6 +10,19 @@ interface DbMember {
   class_programme: string,
   class_year: number,
   picture_path: string,
+}
+
+interface DbCommittee {
+  id: number,
+  name?: string,
+  name_en?: string,
+}
+
+interface DbPosition {
+  id: number,
+  name?: string,
+  name_en?: string,
+  committee_id?: number,
 }
 
 const getMember = async (identifier: {student_id?: string, id?: number}): Promise<DbMember | undefined> => {
@@ -25,7 +39,96 @@ const getMember = async (identifier: {student_id?: string, id?: number}): Promis
     })
 }
 
+interface PositionFilter {
+  id?: number,
+  name?: string,
+  name_en?: string,
+  committee_id?: number,
+}
+
+const getPositions = (filter?: PositionFilter) => {
+  return knex<DbPosition>('positions').select('*').where(dbUtils.camelToSnake(filter))
+}
+
+interface CreatePosition {
+  name: string,
+  committeeId?: number,
+}
+
+interface UpdatePosition {
+  name?: string,
+  committeeId?: number,
+}
+
+const createPosition = ({user}: context.UserContext, input: CreatePosition) => {
+  if (!user) throw new ForbiddenError('Operation denied');
+  return knex('positions').insert(dbUtils.camelToSnake(input));
+}
+
+const updatePosition = async ({user}: context.UserContext, id: number, input: UpdatePosition) => {
+  if (!user) throw new ForbiddenError('Operation denied');
+  if (Object.keys(input).length === 0) return false;
+  return knex('positions').where({id}).update(dbUtils.camelToSnake(input))
+}
+
+const removePosition = ({user}: context.UserContext, id: number) => {
+  if (!user) throw new ForbiddenError('Operation denied');
+  return knex('positions').where({id}).del()
+}
+
+interface CommitteeFilter {
+  id?: number,
+  name?: string,
+  name_en?: string,
+}
+
+const getCommittees = (filter?: CommitteeFilter) => {
+  return knex<DbCommittee>('committees').select('*').where(dbUtils.camelToSnake(filter))
+}
+
+interface CreateCommittee {
+  name: string,
+}
+
+interface UpdateCommittee {
+  name?: string,
+}
+
+const createCommittee = ({user}: context.UserContext, input: CreateCommittee) => {
+  if (!user) throw new ForbiddenError('Operation denied');
+  return knex('committees').insert(dbUtils.camelToSnake(input))
+}
+
+const updateCommittee = async ({user}: context.UserContext, id: number, input: UpdateCommittee) => {
+  if (!user) throw new ForbiddenError('Operation denied');
+  if (Object.keys(input).length === 0) return false;
+  return knex('committee').where({id}).update(dbUtils.camelToSnake(input))
+}
+
+const removeCommittee = ({user}: context.UserContext, id: number) => {
+  if (!user) throw new ForbiddenError('Operation denied');
+  return knex('committee').where({id}).del()
+}
+
 export {
   DbMember,
   getMember,
+
+  DbPosition,
+  PositionFilter,
+  getPositions,
+  CreatePosition,
+  createPosition,
+  UpdatePosition,
+  updatePosition,
+  removePosition,
+
+  DbCommittee,
+  CommitteeFilter,
+  getCommittees,
+  CreateCommittee,
+  createCommittee,
+  UpdateCommittee,
+  updateCommittee,
+  removeCommittee,
 }

--- a/backend/services/members/src/resolvers.ts
+++ b/backend/services/members/src/resolvers.ts
@@ -1,18 +1,83 @@
-import { DbMember, getMember } from './db';
-import { context } from 'dsek-shared';
-
+import {
+  DbMember,
+  getMember,
+  PositionFilter,
+  CommitteeFilter,
+  getCommittees,
+  createCommittee,
+  CreateCommittee,
+  getPositions,
+  DbPosition,
+  UpdateCommittee,
+  updateCommittee,
+  removeCommittee,
+  CreatePosition,
+  createPosition,
+  updatePosition,
+  UpdatePosition,
+  removePosition,
+} from './db';
+import { context, dbUtils } from 'dsek-shared';
 
 export default {
   Query: {
-    async me({}, {}, context: context.UserContext) {
-      if (!context.user?.student_id) return undefined;
-      const me = await getMember({student_id: context.user.student_id});
+    async me({}, {}, {user, roles}: context.UserContext) {
+      if (!user?.student_id) return undefined;
+      const me = await getMember({student_id: user.student_id});
       return me;
+    },
+    positions: ({}, {filter}: {filter?: PositionFilter}) => {
+      return getPositions(filter);
+    },
+    committees: ({}, {filter}: {filter?: CommitteeFilter}) => {
+      return getCommittees(filter);
     }
   },
   Member: {
     async __resolveReference(member: DbMember) {
       return await getMember({id: member.id});
+    }
+  },
+  Committee: {
+    __resolveReference: (committee: CommitteeFilter) =>
+      dbUtils.unique(getCommittees(committee)),
+  },
+  Position: {
+    __resolveReference: (position: PositionFilter) =>
+      dbUtils.unique(getPositions(position)),
+    committee: (parent: DbPosition) =>
+      dbUtils.unique(getCommittees({id: parent.committee_id}))
+  },
+  Mutation: {
+    committee: () => ({}),
+    position: () => ({}),
+  },
+  CommitteeMutations: {
+    create: ({}, {input}: {input: CreateCommittee}, {user, roles}: context.UserContext) => {
+      return createCommittee({user, roles}, input)
+        .then((res) => (res) ? true : false);
+    },
+    update: ({}, {id, input}: {id: number, input: UpdateCommittee}, {user, roles}: context.UserContext) => {
+      return updateCommittee({user, roles}, id, input)
+        .then((res) => (res) ? true : false);
+    },
+    remove: ({}, {id}: {id: number}, {user, roles}: context.UserContext) => {
+      return removeCommittee({user, roles}, id)
+        .then((res) => (res) ? true : false);
+    }
+  },
+  PositionMutations: {
+    create: ({}, {input}: {input: CreatePosition}, {user, roles}: context.UserContext) => {
+      return createPosition({user, roles}, input)
+        .then((res) => (res) ? true : false);
+    },
+    update: ({}, {id, input}: {id: number, input: UpdatePosition}, {user, roles}: context.UserContext) => {
+      return updatePosition({user, roles}, id, input)
+        .then((res) => (res) ? true : false);
+    },
+    remove: ({}, {id}: {id: number}, {user, roles}: context.UserContext) => {
+      return removePosition({user, roles}, id)
+        .then((res) => (res) ? true : false);
     }
   }
 };

--- a/backend/services/members/src/typeDefs.ts
+++ b/backend/services/members/src/typeDefs.ts
@@ -3,6 +3,13 @@ import { gql } from 'apollo-server';
 export default gql`
 extend type Query {
   me: Member
+  positions(filter: PositionFilter): [Position!]!
+  committees(filter: CommitteeFilter): [Committee!]!
+}
+
+extend type Mutation {
+  position: PositionMutations
+  committee: CommitteeMutations
 }
 
 type Member @key(fields: "id") {
@@ -14,5 +21,57 @@ type Member @key(fields: "id") {
   class_programme: String
   class_year: Int
   picture_path: String
+}
+
+type Position @key(fields: "id") {
+  id: Int!
+  name: String!
+  committee: Committee
+}
+
+type Committee @key(fields: "id") {
+  id: Int!
+  name: String!
+}
+
+input CommitteeFilter {
+  id: Int
+  name: String
+}
+
+input PositionFilter {
+  id: Int
+  name: String
+  committeeId: Int
+}
+
+type PositionMutations {
+  create(input: CreatePosition!): Boolean
+  update(id: Int!, input: UpdatePosition!): Boolean
+  remove(id: Int!): Boolean
+}
+
+type CommitteeMutations {
+  create(input: CreateCommittee!): Boolean
+  update(id: Int!, input: UpdateCommittee!): Boolean
+  remove(id: Int!): Boolean
+}
+
+input CreatePosition {
+  name: String!
+  committeeId: Int
+}
+
+input UpdatePosition {
+  name: String
+  committeeId: Int
+}
+
+input CreateCommittee {
+  name: String!
+}
+
+input UpdateCommittee {
+  name: String
 }
 `;

--- a/backend/shared/src/database.ts
+++ b/backend/shared/src/database.ts
@@ -3,4 +3,16 @@ import configs from './knexfile';
 
 const config = configs[process.env.NODE_ENV || 'development'];
 
+export const unique = async <T>(promise: Promise<T[] | undefined>) => {
+  const list = await promise;
+  if (!list || list.length != 1) return null;
+  return list[0];
+}
+
+export const camelToSnake = (obj?: {[index: string]: any}) => {
+  if (!obj) return {};
+  const convertKey = (str: string) => str.replace(/[A-Z]/g, letter => `_${letter.toLowerCase()}`);
+  return Object.keys(obj).reduce((prev, key) => ({...prev, [convertKey(key)]: obj[key]}), {})
+}
+
 export default knex(config);

--- a/backend/shared/src/index.ts
+++ b/backend/shared/src/index.ts
@@ -1,9 +1,11 @@
 import * as datetime from './datetime';
-import database from './database';
+import knex from './database';
+import * as dbUtils from './database';
 import * as context from './context';
 
 export {
   datetime,
-  database,
+  knex,
+  dbUtils,
   context,
 }


### PR DESCRIPTION
Closes #40 

Depends on #26 

Adds queries and mutations for positions and committees. The mutations can be accessed by any signed-in user, this is temporary since our access group system isn't defined.