### PR TITLE
feature(#111): adds skeletons while loading news

### DIFF
--- a/frontend/components/News/articleSet.tsx
+++ b/frontend/components/News/articleSet.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import { useNewsPageQuery } from '../../generated/graphql';
 import Article from './article';
 import { useTranslation } from 'next-i18next';
+import ArticleSkeleton from './articleSkeleton';
+import { useKeycloak } from '@react-keycloak/ssr';
+import { KeycloakInstance } from 'keycloak-js';
 
 type newsPageProps = {
   pageIndex?: number,
@@ -14,10 +17,17 @@ export default function ArticleSet({ pageIndex = 0, articlesPerPage = 10, fullAr
   const { loading, data } = useNewsPageQuery({
     variables: { page_number: pageIndex, per_page: articlesPerPage }
   });
+  const { initialized } = useKeycloak<KeycloakInstance>();
   const { t } = useTranslation('news');
 
-  if (loading)
-    return (<p>{t('loadingNews')}</p>)
+  if (loading || !initialized)
+    return (
+      <>
+        <ArticleSkeleton />
+        <ArticleSkeleton />
+        <ArticleSkeleton />
+      </>
+    )
 
   if (!data?.news)
     return (<p>{t('failedLoadingNews')}</p>)

--- a/frontend/components/News/articleSkeleton.tsx
+++ b/frontend/components/News/articleSkeleton.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Grid from '@material-ui/core/Grid'
+import { articleStyles } from './articlestyles'
+import Paper from '@material-ui/core/Paper';
+import Skeleton from '@material-ui/core/Skeleton';
+import Typography from '@material-ui/core/Typography';
+
+
+export default function ArticleSkeleton() {
+    const classes = articleStyles();
+
+    return (
+        <Paper className={classes.article}>
+            <Grid
+                container
+                direction="row"
+                justifyContent="space-evenly"
+                alignItems="flex-start"
+                style={{ position: "relative" }}
+            >
+                <Grid item xs={12} md={12} lg={7} style={{ minHeight: "140px" }}>
+                    <Typography variant="h3"><Skeleton /></Typography>
+                    <Skeleton />
+                    <Skeleton />
+                </Grid>
+
+
+                <Grid item xs={12} md={12} lg={5} className={classes.imageGrid}>'
+                    <Skeleton variant="rectangular" className={classes.image} width={200} height={200} />
+                </Grid>
+
+                <Grid item xs={12} className={classes.footer}>
+                    <br />
+                    <br />
+                    <Typography variant="body1"  >
+                        <Skeleton width={200} />
+                    </Typography>
+                    <Typography variant="body1"  >
+                        <Skeleton width={200} />
+                    </Typography>
+                </Grid>
+            </Grid>
+        </Paper>
+    )
+}

--- a/frontend/pages/news.tsx
+++ b/frontend/pages/news.tsx
@@ -12,7 +12,6 @@ const articlesPerPage = 10
 
 export default function NewsPage() {
   const router = useRouter();
-
   const [pageIndex, setPageIndex] = useState(0);
   const { t } = useTranslation('common');
 
@@ -28,9 +27,6 @@ export default function NewsPage() {
     },
     [router.pathname]
   )
-
-  if (loading)
-    return (<p></p>)
 
   if (!data?.news)
     return (<p></p>)
@@ -63,7 +59,7 @@ export default function NewsPage() {
         </Grid>
       </Grid>
     </DefaultLayout>
-      
+
   )
 }
 


### PR DESCRIPTION
Implements skeletons for articles during load. See attached screenshots for an example.

Closes #111 

![screencapture-localhost-3000-2021-04-09-01_34_03](https://user-images.githubusercontent.com/7382555/114108648-c96fc980-98d3-11eb-98d0-a49d8ccfb7fa.png)
![screencapture-localhost-3000-news-article-73-2021-04-09-01_32_02](https://user-images.githubusercontent.com/7382555/114108646-c8d73300-98d3-11eb-954e-3eeb748ce5ab.png)

