### PR TITLE
feature(#73) Adds creating and editing news pages

### DIFF
--- a/backend/services/calendar/src/types/graphql.ts
+++ b/backend/services/calendar/src/types/graphql.ts
@@ -1,6 +1,8 @@
 import { GraphQLResolveInfo, GraphQLScalarType, GraphQLScalarTypeConfig } from 'graphql';
 export type Maybe<T> = T | undefined;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
+export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
 export type RequireFields<T, K extends keyof T> = { [X in Exclude<keyof T, K>]?: T[X] } & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {

--- a/frontend/api/news.graphql
+++ b/frontend/api/news.graphql
@@ -68,3 +68,11 @@ mutation CreateArticle($header:String!, $body:String!, $headerEn:String!, $bodyE
     }
   }
 }
+
+mutation RemoveArticle($id:Int!) {
+  article{
+    remove(id: $id){
+      id
+    }
+  }
+}

--- a/frontend/api/news.graphql
+++ b/frontend/api/news.graphql
@@ -5,6 +5,7 @@ query NewsPage($page_number:Int!, $per_page:Int!) {
       header
       body
       author {
+        id
         first_name
         last_name
       }
@@ -32,11 +33,38 @@ query Article($id:Int!) {
   article(id: $id) {
     id
     body
+    body_en
     header
+    header_en
     author {
+      id
       first_name
       last_name
     }
     published_datetime
+  }
+}
+
+mutation UpdateArticle($id:Int!, $header:String, $body:String, $headerEn:String, $bodyEn:String) {
+  article{
+    update(id: $id, input: {header: $header, body: $body, header_en: $headerEn, body_en: $bodyEn}) {
+      id
+      header
+      body
+      header_en
+      body_en
+    }
+  }
+}
+
+mutation CreateArticle($header:String!, $body:String!, $headerEn:String!, $bodyEn:String!) {
+  article{
+    create(input: {header: $header, body: $body, header_en: $headerEn, body_en: $bodyEn}){
+      id
+      header
+      body
+      header_en 
+      body_en
+    }
   }
 }

--- a/frontend/components/ArticleEditor/ArticleEditorItem/articleEditorItemStyles.tsx
+++ b/frontend/components/ArticleEditor/ArticleEditorItem/articleEditorItemStyles.tsx
@@ -2,6 +2,11 @@ import { makeStyles } from '@material-ui/core/styles';
 
 export const articleEditorItemStyles = makeStyles(theme => ({
     uploadButton: {
-        marginLeft: theme.spacing(2),
+        [theme.breakpoints.up('sm')]: {
+            marginLeft: theme.spacing(2),
+        },
+        [theme.breakpoints.down('sm')]: {
+            marginTop: theme.spacing(2),
+        },
     }
 }))

--- a/frontend/components/ArticleEditor/ArticleEditorItem/articleEditorItemStyles.tsx
+++ b/frontend/components/ArticleEditor/ArticleEditorItem/articleEditorItemStyles.tsx
@@ -1,0 +1,7 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export const articleEditorItemStyles = makeStyles(theme => ({
+    uploadButton: {
+        marginLeft: theme.spacing(2),
+    }
+}))

--- a/frontend/components/ArticleEditor/ArticleEditorItem/index.tsx
+++ b/frontend/components/ArticleEditor/ArticleEditorItem/index.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { useTranslation } from 'next-i18next';
+//@ts-ignore package does not have typescript types
+import ReactMde from 'react-mde';
+import "react-mde/lib/styles/css/react-mde-all.css";
+import ReactMarkdown from 'react-markdown';
+import { Button, Input, Stack, Tab, Tabs, TextField } from '@material-ui/core';
+import { articleEditorItemStyles } from './articleEditorItemStyles';
+
+type EditorProps = {
+    header: string,
+    body: string,
+    selectedTab: "write" | "preview",
+    onTabChange: (tab: "write" | "preview") => void,
+    onHeaderChange: (event: React.ChangeEvent<HTMLInputElement>) => void,
+    onBodyChange: (value: string) => void
+}
+
+export default function ArticleEditorItem({
+    header,
+    body,
+    selectedTab,
+    onTabChange,
+    onHeaderChange,
+    onBodyChange,
+}: EditorProps) {
+    const classes = articleEditorItemStyles();
+
+    const { t } = useTranslation(['common', 'news']);
+
+    return (
+        <Stack spacing={2} >
+            <TextField
+                id="header-field"
+                label={t('news:header')}
+                onChange={onHeaderChange}
+                multiline
+                value={header} />
+
+            <label htmlFor="contained-button-file">
+                <Input id="contained-button-file" type="file" />
+                <Button variant="outlined" component="span" className={classes.uploadButton}>
+                    {t('upload')}
+                </Button>
+            </label>
+
+            <ReactMde
+                value={body}
+                onChange={onBodyChange}
+                selectedTab={selectedTab}
+                onTabChange={onTabChange}
+                l18n={{
+                    write: t('news:write'),
+                    preview: t('news:preview'),
+                    uploadingImage: t('news:uploadingImage'),
+                    pasteDropSelect: t('news:pasteDropSelect'),
+                }}
+                generateMarkdownPreview={(markdown) =>
+                    Promise.resolve(<ReactMarkdown source={markdown} />)
+                }
+            />
+        </Stack>
+    )
+}

--- a/frontend/components/ArticleEditor/ArticleEditorSkeleton/articleEditorSkeletonStyles.tsx
+++ b/frontend/components/ArticleEditor/ArticleEditorSkeleton/articleEditorSkeletonStyles.tsx
@@ -1,0 +1,7 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export const articleEditorSkeletonStyles = makeStyles(theme => ({
+   container: {
+    padding: "1em",
+   }
+}))

--- a/frontend/components/ArticleEditor/ArticleEditorSkeleton/index.tsx
+++ b/frontend/components/ArticleEditor/ArticleEditorSkeleton/index.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import Paper from '@material-ui/core/Paper';
+import Skeleton from '@material-ui/core/Skeleton';
+import Typography from '@material-ui/core/Typography';
+import { articleEditorSkeletonStyles } from './articleEditorSkeletonStyles';
+import { Stack } from '@material-ui/core';
+
+export default function ArticleEditorSkeleton() {
+    const classes = articleEditorSkeletonStyles();
+
+    return (
+        <Paper className={classes.container}>
+            <Stack spacing={2} >
+                <Typography variant="h1"><Skeleton /></Typography>
+                <Typography variant="h3"><Skeleton /></Typography>
+                <Typography variant="h3"><Skeleton /></Typography>
+                <Skeleton variant="rectangular" height={200} />
+
+            </Stack>
+
+        </Paper>
+    )
+}

--- a/frontend/components/ArticleEditor/articleEditorStyles.tsx
+++ b/frontend/components/ArticleEditor/articleEditorStyles.tsx
@@ -1,0 +1,5 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+export const articleEditorStyles = makeStyles(theme => ({
+
+}))

--- a/frontend/components/ArticleEditor/index.tsx
+++ b/frontend/components/ArticleEditor/index.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+import { useTranslation } from 'next-i18next';
+import { articleEditorStyles } from './articleEditorStyles'
+import "react-mde/lib/styles/css/react-mde-all.css";
+import { Box, Tab, Tabs } from '@material-ui/core';
+import SaveIcon from '@material-ui/icons/Save';
+import { LoadingButton, TabContext, TabPanel } from '@material-ui/lab';
+import { MutationFunctionOptions } from '@apollo/client';
+import ArticleEditorItem from './ArticleEditorItem';
+
+type translationObject = {
+    sv: string,
+    en: string
+}
+
+type EditorProps = {
+    header: translationObject,
+    onHeaderChange: (translationObject: translationObject) => void
+    body: translationObject
+    onBodyChange: (translationObject: translationObject) => void
+    selectedTab: "write" | "preview",
+    onTabChange: (tab: "write" | "preview") => void,
+    loading: boolean,
+    onSubmit: (options?: MutationFunctionOptions) => void,
+    saveButtonText: string,
+}
+
+export default function ArticleEditor({
+    header,
+    onHeaderChange,
+    body,
+    onBodyChange,
+    selectedTab,
+    onTabChange,
+    loading,
+    onSubmit,
+    saveButtonText,
+}: EditorProps) {
+    const classes = articleEditorStyles();
+
+    const { t } = useTranslation(['common', 'news']);
+
+    const handleHeaderChange = (event: React.ChangeEvent<HTMLInputElement>, tag:string) => {
+        onHeaderChange({
+            ...header,
+            [tag]: event.target.value,
+        });
+    }
+
+    const handleBodyChange = (value: string, tag:string) => {
+        onBodyChange({
+            ...body,
+            [tag]: value,
+        });
+    };
+
+
+    const [value, setValue] = React.useState("sv");
+
+    const handleTabChange = (event: React.SyntheticEvent, newTab: string) => {
+        setValue(newTab);
+    };
+
+    return (
+        <Box
+            component="form"
+            noValidate
+            autoComplete="off"
+        >
+            <TabContext value={value}>
+                <Tabs
+                    value={value}
+                    onChange={handleTabChange}
+                    textColor="primary"
+                    indicatorColor="primary"
+                    aria-label="secondary tabs example"
+                >
+                    <Tab value="sv" label={t('swedish')} />
+                    <Tab value="en" label={t('english')} />
+                </Tabs>
+
+                <TabPanel value="sv">
+                    <ArticleEditorItem
+                        header={header.sv}
+                        body={body.sv}
+                        selectedTab={selectedTab}
+                        onTabChange={onTabChange}
+                        onHeaderChange={(event) => handleHeaderChange(event, "sv")}
+                        onBodyChange={(value) => handleBodyChange(value, "sv")}
+                    />
+                </TabPanel>
+                <TabPanel value="en">
+                    <ArticleEditorItem
+                        header={header.en}
+                        body={body.en}
+                        selectedTab={selectedTab}
+                        onTabChange={onTabChange}
+                        onHeaderChange={(event) => handleHeaderChange(event, "en")}
+                        onBodyChange={(value) => handleBodyChange(value, "en")}
+                    />
+                </TabPanel>
+            </TabContext>
+
+            <LoadingButton
+                loading={loading}
+                loadingPosition="start"
+                startIcon={<SaveIcon />}
+                variant="outlined"
+                onClick={() => {
+                    onSubmit()
+                }}
+            >
+                {saveButtonText}
+            </LoadingButton>
+
+        </Box>
+    )
+}

--- a/frontend/components/Data/index.tsx
+++ b/frontend/components/Data/index.tsx
@@ -1,18 +1,18 @@
-import React from 'react';
-import { useMeHeaderQuery } from '../../generated/graphql';
+import React, { useContext }from 'react';
+import UserContext from '~/providers/UserProvider';
 
 export default function Data() {
-    const { loading, data } = useMeHeaderQuery();
+  const {user, loading} = useContext(UserContext);
     return (
       <div>
         <h1>Inloggad som</h1>
         { loading ? (
           <p>loading...</p>
-        ) : (data?.me ? (
+        ) : (user ? (
           <div>
-            <p>Namn: {data.me.first_name} {data.me.last_name}</p>
-            <p>Stil-ID: {data.me.student_id}</p>
-            <img src={`http://localhost:4000${data.me.picture_path}`} alt="profilbild" />
+            <p>Namn: {user.first_name} {user.last_name}</p>
+            <p>Stil-ID: {user.student_id}</p>
+            <img src={`http://localhost:4000${user.picture_path}`} alt="profilbild" />
           </div>
         ) : (
             <p>Misslyckades med att hämnta den inloggade</p>

--- a/frontend/components/Header/index.tsx
+++ b/frontend/components/Header/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { useTranslation } from 'next-i18next';
 import {
   Backdrop,
@@ -19,10 +19,10 @@ import ButtonBase from '@material-ui/core/ButtonBase';
 import { useKeycloak } from '@react-keycloak/ssr';
 import { KeycloakInstance } from 'keycloak-js';
 import Link from 'next/link';
-import { useMeHeaderQuery } from '../../generated/graphql';
 import DsekIcon from '../Icons/DsekIcon';
 import UserAvatar from '../UserAvatar';
 import routes from '~/routes';
+import UserContext from '~/providers/UserProvider';
 
 const useHeaderStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -86,15 +86,15 @@ function Account() {
   const [ open, setOpen ] = useState(false);
 
   const { keycloak, initialized } = useKeycloak<KeycloakInstance>();
-  const { loading, data } = useMeHeaderQuery();
+  const {user, loading} = useContext(UserContext);
   const { t } = useTranslation('common');
 
   if (!keycloak) return <div></div>
   if (!keycloak?.authenticated) return <Button onClick={() => keycloak.login()}>{t('sign in')}</Button>
   if (loading || !initialized) return <CircularProgress color='inherit' size={theme.spacing(4)}/>
-  if (!data?.me) return <Typography>{t('failed')}</Typography>
+  if (!user) return <Typography>{t('failed')}</Typography>
 
-  const name = `${data.me.first_name} ${data.me.last_name}`;
+  const name = `${user.first_name} ${user.last_name}`;
   return (
     <div>
       <ButtonBase className={classes.avatar} disableRipple onClick={() => setOpen(true)}>
@@ -105,11 +105,11 @@ function Account() {
           <CardContent>
             <Typography variant='overline'> {t('logged in as')} </Typography>
             <Typography variant='h6'> {name} </Typography>
-            <Typography variant='subtitle1' gutterBottom>{data.me.student_id}</Typography>
+            <Typography variant='subtitle1' gutterBottom>{user.student_id}</Typography>
             <UserAvatar centered src='' size={8}/>
           </CardContent>
           <CardContent>
-            <Link href={routes.member(data.me.id)}>
+            <Link href={routes.member(user.id)}>
               <Button variant='outlined'>{t('show profile')}</Button>
             </Link>
           </CardContent>

--- a/frontend/components/News/article.tsx
+++ b/frontend/components/News/article.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Paper } from '@material-ui/core';
 import { useTranslation } from 'next-i18next';
 import Grid from '@material-ui/core/Grid'
@@ -9,7 +9,7 @@ import Link from 'next/link';
 import routes from '~/routes';
 //@ts-ignore package does not have typescript types
 import truncateMarkdown from 'markdown-truncate';
-
+import UserContext from '~/providers/UserProvider';
 
 type ArticleProps = {
     title: string,
@@ -17,6 +17,7 @@ type ArticleProps = {
     imageUrl: string | undefined,
     publishDate: string,
     author: string,
+    authorId: number,
     id: string,
     fullArticle: boolean,
 }
@@ -25,6 +26,7 @@ export default function Article(props: ArticleProps) {
     const classes = articleStyles();
     const date = DateTime.fromISO(props.publishDate);
     const { t } = useTranslation('common');
+    const { user, loading: userLoading } = useContext(UserContext);
 
     let markdown = props.children;
     if (!props.fullArticle)
@@ -55,6 +57,14 @@ export default function Article(props: ArticleProps) {
                     <br /><br />
                     <span>{props.author}</span><br />
                     <span>{date.setLocale('sv').toISODate()}</span>
+
+                    {!userLoading && user.id == props.authorId && (<>
+                        <br />
+                        <Link href={routes.editArticle(props.id)}>
+                            {t('edit')}
+                        </Link>
+                    </>)}
+
                 </Grid>
             </Grid>
         </Paper>

--- a/frontend/components/News/article.tsx
+++ b/frontend/components/News/article.tsx
@@ -58,7 +58,7 @@ export default function Article(props: ArticleProps) {
                     <span>{props.author}</span><br />
                     <span>{date.setLocale('sv').toISODate()}</span>
 
-                    {!userLoading && user.id == props.authorId && (<>
+                    {!userLoading && user?.id == props.authorId && (<>
                         <br />
                         <Link href={routes.editArticle(props.id)}>
                             {t('edit')}

--- a/frontend/components/News/articleSet.tsx
+++ b/frontend/components/News/articleSet.tsx
@@ -42,6 +42,7 @@ export default function ArticleSet({ pageIndex = 0, articlesPerPage = 10, fullAr
               publishDate={article.published_datetime}
               imageUrl={undefined}
               author={`${article.author.first_name} ${article.author.last_name}`}
+              authorId={article.author.id}
               id={article.id.toString()}
               fullArticle={fullArticles}>
               {article.body}

--- a/frontend/generated/graphql.tsx
+++ b/frontend/generated/graphql.tsx
@@ -396,7 +396,7 @@ export type NewsPageQuery = (
       & Pick<Article, 'id' | 'header' | 'body' | 'published_datetime' | 'latest_edit_datetime'>
       & { author: (
         { __typename?: 'Member' }
-        & Pick<Member, 'first_name' | 'last_name'>
+        & Pick<Member, 'id' | 'first_name' | 'last_name'>
       ) }
     )>>, pageInfo: (
       { __typename?: 'PaginationInfo' }
@@ -431,11 +431,50 @@ export type ArticleQuery = (
   { __typename?: 'Query' }
   & { article?: Maybe<(
     { __typename?: 'Article' }
-    & Pick<Article, 'id' | 'body' | 'header' | 'published_datetime'>
+    & Pick<Article, 'id' | 'body' | 'body_en' | 'header' | 'header_en' | 'published_datetime'>
     & { author: (
       { __typename?: 'Member' }
-      & Pick<Member, 'first_name' | 'last_name'>
+      & Pick<Member, 'id' | 'first_name' | 'last_name'>
     ) }
+  )> }
+);
+
+export type UpdateArticleMutationVariables = Exact<{
+  id: Scalars['Int'];
+  header?: Maybe<Scalars['String']>;
+  body?: Maybe<Scalars['String']>;
+  headerEn?: Maybe<Scalars['String']>;
+  bodyEn?: Maybe<Scalars['String']>;
+}>;
+
+
+export type UpdateArticleMutation = (
+  { __typename?: 'Mutation' }
+  & { article?: Maybe<(
+    { __typename?: 'ArticleMutations' }
+    & { update?: Maybe<(
+      { __typename?: 'Article' }
+      & Pick<Article, 'id' | 'header' | 'body' | 'header_en' | 'body_en'>
+    )> }
+  )> }
+);
+
+export type CreateArticleMutationVariables = Exact<{
+  header: Scalars['String'];
+  body: Scalars['String'];
+  headerEn: Scalars['String'];
+  bodyEn: Scalars['String'];
+}>;
+
+
+export type CreateArticleMutation = (
+  { __typename?: 'Mutation' }
+  & { article?: Maybe<(
+    { __typename?: 'ArticleMutations' }
+    & { create?: Maybe<(
+      { __typename?: 'Article' }
+      & Pick<Article, 'id' | 'header' | 'body' | 'header_en' | 'body_en'>
+    )> }
   )> }
 );
 
@@ -528,6 +567,7 @@ export const NewsPageDocument = gql`
       header
       body
       author {
+        id
         first_name
         last_name
       }
@@ -615,8 +655,11 @@ export const ArticleDocument = gql`
   article(id: $id) {
     id
     body
+    body_en
     header
+    header_en
     author {
+      id
       first_name
       last_name
     }
@@ -652,3 +695,93 @@ export function useArticleLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Ar
 export type ArticleQueryHookResult = ReturnType<typeof useArticleQuery>;
 export type ArticleLazyQueryHookResult = ReturnType<typeof useArticleLazyQuery>;
 export type ArticleQueryResult = Apollo.QueryResult<ArticleQuery, ArticleQueryVariables>;
+export const UpdateArticleDocument = gql`
+    mutation UpdateArticle($id: Int!, $header: String, $body: String, $headerEn: String, $bodyEn: String) {
+  article {
+    update(
+      id: $id
+      input: {header: $header, body: $body, header_en: $headerEn, body_en: $bodyEn}
+    ) {
+      id
+      header
+      body
+      header_en
+      body_en
+    }
+  }
+}
+    `;
+export type UpdateArticleMutationFn = Apollo.MutationFunction<UpdateArticleMutation, UpdateArticleMutationVariables>;
+
+/**
+ * __useUpdateArticleMutation__
+ *
+ * To run a mutation, you first call `useUpdateArticleMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdateArticleMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updateArticleMutation, { data, loading, error }] = useUpdateArticleMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      header: // value for 'header'
+ *      body: // value for 'body'
+ *      headerEn: // value for 'headerEn'
+ *      bodyEn: // value for 'bodyEn'
+ *   },
+ * });
+ */
+export function useUpdateArticleMutation(baseOptions?: Apollo.MutationHookOptions<UpdateArticleMutation, UpdateArticleMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdateArticleMutation, UpdateArticleMutationVariables>(UpdateArticleDocument, options);
+      }
+export type UpdateArticleMutationHookResult = ReturnType<typeof useUpdateArticleMutation>;
+export type UpdateArticleMutationResult = Apollo.MutationResult<UpdateArticleMutation>;
+export type UpdateArticleMutationOptions = Apollo.BaseMutationOptions<UpdateArticleMutation, UpdateArticleMutationVariables>;
+export const CreateArticleDocument = gql`
+    mutation CreateArticle($header: String!, $body: String!, $headerEn: String!, $bodyEn: String!) {
+  article {
+    create(
+      input: {header: $header, body: $body, header_en: $headerEn, body_en: $bodyEn}
+    ) {
+      id
+      header
+      body
+      header_en
+      body_en
+    }
+  }
+}
+    `;
+export type CreateArticleMutationFn = Apollo.MutationFunction<CreateArticleMutation, CreateArticleMutationVariables>;
+
+/**
+ * __useCreateArticleMutation__
+ *
+ * To run a mutation, you first call `useCreateArticleMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useCreateArticleMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [createArticleMutation, { data, loading, error }] = useCreateArticleMutation({
+ *   variables: {
+ *      header: // value for 'header'
+ *      body: // value for 'body'
+ *      headerEn: // value for 'headerEn'
+ *      bodyEn: // value for 'bodyEn'
+ *   },
+ * });
+ */
+export function useCreateArticleMutation(baseOptions?: Apollo.MutationHookOptions<CreateArticleMutation, CreateArticleMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<CreateArticleMutation, CreateArticleMutationVariables>(CreateArticleDocument, options);
+      }
+export type CreateArticleMutationHookResult = ReturnType<typeof useCreateArticleMutation>;
+export type CreateArticleMutationResult = Apollo.MutationResult<CreateArticleMutation>;
+export type CreateArticleMutationOptions = Apollo.BaseMutationOptions<CreateArticleMutation, CreateArticleMutationVariables>;

--- a/frontend/generated/graphql.tsx
+++ b/frontend/generated/graphql.tsx
@@ -478,6 +478,22 @@ export type CreateArticleMutation = (
   )> }
 );
 
+export type RemoveArticleMutationVariables = Exact<{
+  id: Scalars['Int'];
+}>;
+
+
+export type RemoveArticleMutation = (
+  { __typename?: 'Mutation' }
+  & { article?: Maybe<(
+    { __typename?: 'ArticleMutations' }
+    & { remove?: Maybe<(
+      { __typename?: 'Article' }
+      & Pick<Article, 'id'>
+    )> }
+  )> }
+);
+
 
 export const MeHeaderDocument = gql`
     query MeHeader {
@@ -785,3 +801,38 @@ export function useCreateArticleMutation(baseOptions?: Apollo.MutationHookOption
 export type CreateArticleMutationHookResult = ReturnType<typeof useCreateArticleMutation>;
 export type CreateArticleMutationResult = Apollo.MutationResult<CreateArticleMutation>;
 export type CreateArticleMutationOptions = Apollo.BaseMutationOptions<CreateArticleMutation, CreateArticleMutationVariables>;
+export const RemoveArticleDocument = gql`
+    mutation RemoveArticle($id: Int!) {
+  article {
+    remove(id: $id) {
+      id
+    }
+  }
+}
+    `;
+export type RemoveArticleMutationFn = Apollo.MutationFunction<RemoveArticleMutation, RemoveArticleMutationVariables>;
+
+/**
+ * __useRemoveArticleMutation__
+ *
+ * To run a mutation, you first call `useRemoveArticleMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useRemoveArticleMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [removeArticleMutation, { data, loading, error }] = useRemoveArticleMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function useRemoveArticleMutation(baseOptions?: Apollo.MutationHookOptions<RemoveArticleMutation, RemoveArticleMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<RemoveArticleMutation, RemoveArticleMutationVariables>(RemoveArticleDocument, options);
+      }
+export type RemoveArticleMutationHookResult = ReturnType<typeof useRemoveArticleMutation>;
+export type RemoveArticleMutationResult = Apollo.MutationResult<RemoveArticleMutation>;
+export type RemoveArticleMutationOptions = Apollo.BaseMutationOptions<RemoveArticleMutation, RemoveArticleMutationVariables>;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1229,6 +1229,43 @@
       "resolved": "https://registry.npmjs.org/@csstools/normalize.css/-/normalize.css-10.1.0.tgz",
       "integrity": "sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg=="
     },
+    "@date-io/core": {
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@date-io/core/-/core-2.10.7.tgz",
+      "integrity": "sha512-EG/1qDiQvd12RoNJ6H+sZcHVswC/3uMx/ySvfaJ24vB30rLjkgHggEXbgMbfgki7wMuiQ/zXI8QlmF1k3kWRGQ=="
+    },
+    "@date-io/date-fns": {
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/@date-io/date-fns/-/date-fns-2.10.8.tgz",
+      "integrity": "sha512-T5RXKOt8CnjsKg0Orgbe/ekoafC02nsopS+wve5+6gF11hPfN2QUqXclxYQv1LIZSaAHJJ2gL8y0msOew74QHQ==",
+      "requires": {
+        "@date-io/core": "^2.10.7"
+      }
+    },
+    "@date-io/dayjs": {
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/@date-io/dayjs/-/dayjs-2.10.8.tgz",
+      "integrity": "sha512-up4xsSGNyIfUue5q8CvqR4mYegLECbEFre812yLlM/97MoGvdbQJA1fOxlNLd82geG42XgQh8R/QQmNSJkHQ6A==",
+      "requires": {
+        "@date-io/core": "^2.10.7"
+      }
+    },
+    "@date-io/luxon": {
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/@date-io/luxon/-/luxon-2.10.8.tgz",
+      "integrity": "sha512-BmZ9KJnU6LOJx5i94lCVCaSpys15UYSsl1r3v6PBUKFF93e3pm6m0AhTtAUw0g9aLi+GbT7dAsf60UPl2yWCZg==",
+      "requires": {
+        "@date-io/core": "^2.10.7"
+      }
+    },
+    "@date-io/moment": {
+      "version": "2.10.8",
+      "resolved": "https://registry.npmjs.org/@date-io/moment/-/moment-2.10.8.tgz",
+      "integrity": "sha512-f7vDFqE4ukSsDZOOXe8a5UR4aqb7boN7gDdcGkhCRfmo+41SX3DBJRFkVWxUvoy8l05za/X6nTYksqNvv719Ng==",
+      "requires": {
+        "@date-io/core": "^2.10.7"
+      }
+    },
     "@emotion/babel-plugin": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.2.0.tgz",
@@ -3041,6 +3078,55 @@
       "integrity": "sha512-RMoIBH7LoKSoXVxwC6twvj9gpvNMT3EQCaKrfSAnKOKu/kibmJjEyFpwrj1CWOdfKzdSakyZqSNkUvOQSGvn5Q==",
       "requires": {
         "@babel/runtime": "^7.4.4"
+      }
+    },
+    "@material-ui/lab": {
+      "version": "5.0.0-alpha.32",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-5.0.0-alpha.32.tgz",
+      "integrity": "sha512-YfWfv/QYYIG1OeGuNlJrLzAOUVMWDBEvoSDDXgz4PbZ0vCG9ox7PXRnYEJH80JWe7epJ/pK3ui2m1QXEDdqwNw==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@date-io/date-fns": "^2.10.6",
+        "@date-io/dayjs": "^2.10.6",
+        "@date-io/luxon": "^2.10.6",
+        "@date-io/moment": "^2.10.6",
+        "@material-ui/system": "5.0.0-alpha.31",
+        "@material-ui/utils": "5.0.0-alpha.31",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^17.0.0",
+        "react-transition-group": "^4.4.1",
+        "rifm": "^0.12.0"
+      },
+      "dependencies": {
+        "@material-ui/system": {
+          "version": "5.0.0-alpha.31",
+          "resolved": "https://registry.npmjs.org/@material-ui/system/-/system-5.0.0-alpha.31.tgz",
+          "integrity": "sha512-fHTMpcu3r+1KsNWoK3YSXNiOJjO5LzafPtS31XoWCnW+Dq1wC/hu8Q6u+tUJlxAPRsFCRW+d27Y/a+BWWwFtVQ==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@material-ui/utils": "5.0.0-alpha.31",
+            "csstype": "^3.0.2",
+            "prop-types": "^15.7.2"
+          }
+        },
+        "@material-ui/utils": {
+          "version": "5.0.0-alpha.31",
+          "resolved": "https://registry.npmjs.org/@material-ui/utils/-/utils-5.0.0-alpha.31.tgz",
+          "integrity": "sha512-4OzVD12+HbfWMftwiHCBforgjkhzbWMdK9GTQLQcekjdG2qpi41BGvanPpHjlxegzou0A2MEaULBvWqsKrUP9A==",
+          "requires": {
+            "@babel/runtime": "^7.4.4",
+            "@types/prop-types": "^15.7.3",
+            "@types/react-is": "^16.7.1 || ^17.0.0",
+            "prop-types": "^15.7.2",
+            "react-is": "^17.0.0"
+          }
+        },
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+        }
       }
     },
     "@material-ui/styled-engine": {
@@ -5590,6 +5676,15 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "bluebird": {
       "version": "3.7.2",
@@ -9564,6 +9659,12 @@
           }
         }
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "6.1.0",
@@ -14708,6 +14809,12 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
+    },
     "nanoid": {
       "version": "3.1.22",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
@@ -18892,6 +18999,11 @@
         "xtend": "^4.0.1"
       }
     },
+    "react-mde": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/react-mde/-/react-mde-11.1.0.tgz",
+      "integrity": "sha512-QNwnpF9vyRSMj2tt2sZAD2IBpcErr6iYo/6k1v6Ln2hixbpeYmBANnuxVKd+D60eBMyFUFAQtWZBKDv3Hl9BqA=="
+    },
     "react-refresh": {
       "version": "0.8.3",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
@@ -19656,6 +19768,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rgba-regex/-/rgba-regex-1.0.0.tgz",
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
+    },
+    "rifm": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/rifm/-/rifm-0.12.0.tgz",
+      "integrity": "sha512-PqOl+Mo2lyqrKiD34FPlnQ+ksD3F+a62TQlphiZshgriyHdfjn6jGyqUZhd+s3nsMYXwXYDdjrrv8wX7QsOG3g=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -22378,7 +22495,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",
@@ -22806,8 +22927,7 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "resolved": "",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }
@@ -23065,7 +23185,11 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "optional": true
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "nan": "^2.12.1"
+          }
         },
         "glob-parent": {
           "version": "3.1.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@emotion/styled": "^11.1.5",
     "@material-ui/core": "^5.0.0-alpha.28",
     "@material-ui/icons": "^5.0.0-alpha.28",
+    "@material-ui/lab": "^5.0.0-alpha.31",
     "@react-keycloak/ssr": "^3.3.0",
     "apollo-client": "^2.6.10",
     "apollo-link-context": "^1.0.20",
@@ -27,6 +28,7 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-markdown": "^5.0.3",
+    "react-mde": "^11.1.0",
     "react-scripts": "^4.0.0"
   },
   "devDependencies": {

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -7,7 +7,7 @@ import createCache from '@emotion/cache';
 import { appWithTranslation } from 'next-i18next'
 import { AppProps } from 'next/app';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-
+import {UserProvider} from '~/providers/UserProvider';
 
 export const cache = createCache({ key: 'css', prepend: true });
 
@@ -26,7 +26,9 @@ function MyApp({ Component, pageProps, cookies }: AppProps & {cookies: any}) {
       <GraphQLProvider>
         <CacheProvider value={cache}>
           <ThemeProvider>
+            <UserProvider>
               <Component {...pageProps} />
+            </UserProvider>
           </ThemeProvider>
         </CacheProvider>
       </GraphQLProvider>

--- a/frontend/pages/news/article/[id].tsx
+++ b/frontend/pages/news/article/[id].tsx
@@ -9,7 +9,6 @@ import ArticleSkeleton from '../../../components/News/articleSkeleton';
 import { useKeycloak } from '@react-keycloak/ssr';
 import { KeycloakInstance } from 'keycloak-js';
 
-
 export default function ArticlePage() {
   const router = useRouter()
   const id = router.query.id as string;
@@ -46,6 +45,7 @@ export default function ArticlePage() {
           publishDate={article.published_datetime}
           imageUrl={undefined}
           author={`${article.author.first_name} ${article.author.last_name}`}
+          authorId={article.author.id}
           id={article.id.toString()}
           fullArticle={true} >
           {article.body}

--- a/frontend/pages/news/article/create.tsx
+++ b/frontend/pages/news/article/create.tsx
@@ -1,0 +1,147 @@
+import React, { useContext, useEffect } from 'react';
+import { useTranslation } from 'next-i18next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useCreateArticleMutation } from '../../../generated/graphql';
+import { useRouter } from 'next/router'
+import ArticleLayout from '../../../layouts/articleLayout';
+import ArticleSkeleton from '../../../components/News/articleSkeleton';
+import { useKeycloak } from '@react-keycloak/ssr';
+import { KeycloakInstance } from 'keycloak-js';
+import ArticleEditor from '~/components/ArticleEditor';
+import Paper from '@material-ui/core/Paper';
+import articleEditorPageStyles from '~/styles/articleEditorPageStyles'
+import { Alert, Collapse, IconButton, Stack, Typography } from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import UserContext from '~/providers/UserProvider';
+
+export default function CreateArticlePage() {
+    const router = useRouter()
+    const { keycloak, initialized } = useKeycloak<KeycloakInstance>();
+
+    const {user, loading: userLoading} = useContext(UserContext);
+
+    const { t } = useTranslation(['common', 'news']);
+    const classes = articleEditorPageStyles();
+
+    const [selectedTab, setSelectedTab] = React.useState<'write' | 'preview'>('write');
+    const [body, setBody] = React.useState({ sv: "", en: "" });
+    const [header, setHeader] = React.useState({ sv: "", en: "" });
+    const [successOpen, setSuccessOpen] = React.useState(false);
+    const [errorOpen, setErrorOpen] = React.useState(false);
+    const [createArticleMutation, { data, loading, error, called }] = useCreateArticleMutation({
+        variables: {
+            header: header.sv,
+            body: body.sv,
+            headerEn: header.en,
+            bodyEn: body.en
+        },
+    });
+
+    useEffect(() => {
+        if (!loading && called) {
+            if (error) {
+                setErrorOpen(true);
+                setSuccessOpen(false);
+            }
+            else {
+                setErrorOpen(false);
+                setSuccessOpen(true);
+            }
+        }
+        else {
+            setSuccessOpen(false);
+            setErrorOpen(false);
+        }
+
+    }, [loading]);
+
+
+    if (!initialized || userLoading) {
+        return (
+            <ArticleLayout>
+                <ArticleSkeleton />
+            </ArticleLayout>
+        )
+    }
+
+
+    if (!keycloak?.authenticated || !user) {
+        return (
+            <ArticleLayout>
+                {t('notAuthenticated')}
+            </ArticleLayout>
+        );
+    }
+
+    return (
+        <ArticleLayout>
+            <Paper className={classes.container}>
+                <Typography variant="h3" component="h1">
+                    {t('news:createArticle')}
+        </Typography>
+
+                <Collapse in={successOpen}>
+                    <Alert
+                        severity="success"
+                        action={
+                            <IconButton
+                                aria-label="close"
+                                color="inherit"
+                                size="small"
+                                onClick={() => {
+                                    setSuccessOpen(false);
+                                }}
+                            >
+                                <CloseIcon fontSize="inherit" />
+                            </IconButton>
+                        }
+                        sx={{ mb: 2 }}
+                    >
+                        {t('news:edit_saved')}
+                    </Alert>
+                </Collapse>
+
+                <Collapse in={errorOpen}>
+                    <Alert
+                        severity="error"
+                        action={
+                            <IconButton
+                                aria-label="close"
+                                color="inherit"
+                                size="small"
+                                onClick={() => {
+                                    setErrorOpen(false);
+                                }}
+                            >
+                                <CloseIcon fontSize="inherit" />
+                            </IconButton>
+                        }
+                        sx={{ mb: 2 }}
+                    >
+                        {t('error')}
+                    </Alert>
+                </Collapse>
+
+                <ArticleEditor
+                    header={header}
+                    onHeaderChange={setHeader}
+                    body={body}
+                    onBodyChange={setBody}
+                    selectedTab={selectedTab}
+                    onTabChange={setSelectedTab}
+                    loading={loading}
+                    onSubmit={createArticleMutation}
+                    saveButtonText={t('save')}
+                />
+            </Paper>    
+        </ArticleLayout >
+    )
+}
+
+export async function getServerSideProps({ locale }) {
+    return {
+        props: {
+            ...await serverSideTranslations(locale, ['common', 'news']),
+        }
+    }
+}

--- a/frontend/pages/news/article/create.tsx
+++ b/frontend/pages/news/article/create.tsx
@@ -4,7 +4,6 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useCreateArticleMutation } from '../../../generated/graphql';
 import { useRouter } from 'next/router'
 import ArticleLayout from '../../../layouts/articleLayout';
-import ArticleSkeleton from '../../../components/News/articleSkeleton';
 import { useKeycloak } from '@react-keycloak/ssr';
 import { KeycloakInstance } from 'keycloak-js';
 import ArticleEditor from '~/components/ArticleEditor';
@@ -13,6 +12,7 @@ import articleEditorPageStyles from '~/styles/articleEditorPageStyles'
 import { Alert, Collapse, IconButton, Stack, Typography } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 import UserContext from '~/providers/UserProvider';
+import ArticleEditorSkeleton from '~/components/ArticleEditor/ArticleEditorSkeleton';
 
 export default function CreateArticlePage() {
     const router = useRouter()
@@ -59,7 +59,7 @@ export default function CreateArticlePage() {
     if (!initialized || userLoading) {
         return (
             <ArticleLayout>
-                <ArticleSkeleton />
+                <ArticleEditorSkeleton />
             </ArticleLayout>
         )
     }

--- a/frontend/pages/news/article/edit/[id].tsx
+++ b/frontend/pages/news/article/edit/[id].tsx
@@ -1,0 +1,173 @@
+import React, { useContext, useEffect } from 'react';
+import { useTranslation } from 'next-i18next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import { useArticleQuery, useUpdateArticleMutation } from '../../../../generated/graphql';
+import { useRouter } from 'next/router'
+import ArticleLayout from '../../../../layouts/articleLayout';
+import ArticleSkeleton from '../../../../components/News/articleSkeleton';
+import { useKeycloak } from '@react-keycloak/ssr';
+import { KeycloakInstance } from 'keycloak-js';
+import ArticleEditor from '~/components/ArticleEditor';
+import Paper from '@material-ui/core/Paper';
+import articleEditorPageStyles from '~/styles/articleEditorPageStyles'
+import { Alert, Collapse, IconButton, Typography } from '@material-ui/core';
+import CloseIcon from '@material-ui/icons/Close';
+import UserContext from '~/providers/UserProvider';
+
+export default function EditArticlePage() {
+  const router = useRouter()
+  const id = router.query.id as string;
+  const { keycloak, initialized } = useKeycloak<KeycloakInstance>();
+  const articleQuery = useArticleQuery({
+    variables: { id: parseInt(id) ? parseInt(id) : 0 }
+  });
+
+  const {user, loading: userLoading} = useContext(UserContext);
+
+  const { t } = useTranslation(['common', 'news']);
+  const classes = articleEditorPageStyles();
+
+  const [selectedTab, setSelectedTab] = React.useState<'write' | 'preview'>('write');
+  const [body, setBody] = React.useState({sv: "", en: ""});
+  const [header, setHeader] = React.useState({sv: "", en: ""});
+  const [successOpen, setSuccessOpen] = React.useState(false);
+  const [errorOpen, setErrorOpen] = React.useState(false);
+  const [updateArticle, articleMutationStatus] = useUpdateArticleMutation({
+    variables: {
+      id: Number.parseInt(id),
+      header: header.sv,
+      headerEn: header.en,
+      body: body.sv,
+      bodyEn: body.en
+    }
+  })
+
+  useEffect(() => {
+    setBody({
+      sv: articleQuery.data?.article.body || "",
+      en:  articleQuery.data?.article.body_en || "",
+    })
+    setHeader({
+      sv: articleQuery.data?.article.header || "",
+      en:  articleQuery.data?.article.header_en || "",
+    })
+  }, [articleQuery.data]);
+
+  useEffect(() =>  {
+    if(!articleMutationStatus.loading && articleMutationStatus.called){
+      if(articleMutationStatus.error){
+        setErrorOpen(true);
+        setSuccessOpen(false);
+      }
+      else{
+        setErrorOpen(false);
+        setSuccessOpen(true);
+      }
+    }
+    else
+    {
+      setSuccessOpen(false);
+      setErrorOpen(false);
+    }
+   
+  }, [articleMutationStatus.loading]);
+
+
+  if (articleQuery.loading || !initialized || userLoading) {
+    return (
+      <ArticleLayout>
+        <ArticleSkeleton />
+      </ArticleLayout>
+    )
+  }
+
+  const article = articleQuery.data?.article;
+
+  if (!article) {
+    return (
+      <ArticleLayout>
+        {t('articleError')}
+      </ArticleLayout>
+    );
+  }
+
+  if (!keycloak?.authenticated || user?.id !== article.author.id) {
+    return (
+      <ArticleLayout>
+        {t('notAuthenticated')}
+      </ArticleLayout>
+    );
+  }
+
+  return (
+    <ArticleLayout>
+      <Paper className={classes.container}>
+        <Typography variant="h3"  component="h1">
+        {t('news:editArticle')}
+        </Typography>
+
+        <Collapse in={successOpen}>
+          <Alert
+            severity="success"
+            action={
+              <IconButton
+                aria-label="close"
+                color="inherit"
+                size="small"
+                onClick={() => {
+                  setSuccessOpen(false);
+                }}
+              >
+                <CloseIcon fontSize="inherit" />
+              </IconButton>
+            }
+            sx={{ mb: 2 }}
+          >
+            {t('news:edit_saved')}
+        </Alert>
+        </Collapse>
+
+        <Collapse in={errorOpen}>
+          <Alert
+            severity="error"
+            action={
+              <IconButton
+                aria-label="close"
+                color="inherit"
+                size="small"
+                onClick={() => {
+                  setErrorOpen(false);
+                }}
+              >
+                <CloseIcon fontSize="inherit" />
+              </IconButton>
+            }
+            sx={{ mb: 2 }}
+          >
+            {t('error')}
+        </Alert>
+        </Collapse>
+
+        <ArticleEditor
+          header={header}
+          onHeaderChange={setHeader}
+          body={body}
+          onBodyChange={setBody}
+          selectedTab={selectedTab}
+          onTabChange={setSelectedTab}
+          loading={articleMutationStatus.loading}
+          onSubmit={updateArticle}
+          saveButtonText={t('update')}
+        />
+      </Paper>
+    </ArticleLayout >
+  )
+}
+
+export async function getServerSideProps ({ locale }) {
+  return {
+    props: {
+      ...await serverSideTranslations(locale, ['common', 'news']),
+    }
+  }
+}

--- a/frontend/pages/news/article/edit/[id].tsx
+++ b/frontend/pages/news/article/edit/[id].tsx
@@ -4,7 +4,6 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useArticleQuery, useUpdateArticleMutation } from '../../../../generated/graphql';
 import { useRouter } from 'next/router'
 import ArticleLayout from '../../../../layouts/articleLayout';
-import ArticleSkeleton from '../../../../components/News/articleSkeleton';
 import { useKeycloak } from '@react-keycloak/ssr';
 import { KeycloakInstance } from 'keycloak-js';
 import ArticleEditor from '~/components/ArticleEditor';
@@ -13,6 +12,7 @@ import articleEditorPageStyles from '~/styles/articleEditorPageStyles'
 import { Alert, Collapse, IconButton, Typography } from '@material-ui/core';
 import CloseIcon from '@material-ui/icons/Close';
 import UserContext from '~/providers/UserProvider';
+import ArticleEditorSkeleton from '~/components/ArticleEditor/ArticleEditorSkeleton';
 
 export default function EditArticlePage() {
   const router = useRouter()
@@ -76,7 +76,7 @@ export default function EditArticlePage() {
   if (articleQuery.loading || !initialized || userLoading) {
     return (
       <ArticleLayout>
-        <ArticleSkeleton />
+        <ArticleEditorSkeleton />
       </ArticleLayout>
     )
   }

--- a/frontend/providers/UserProvider.tsx
+++ b/frontend/providers/UserProvider.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react'
+import { useMeHeaderQuery, Member } from '~/generated/graphql';
+
+type userContextReturn = {
+    user: Member,
+    loading: boolean
+}
+
+const defaultContext:userContextReturn = {
+    user: undefined,
+    loading: true
+}
+
+const UserContext = React.createContext(defaultContext)
+
+export function UserProvider({ children }) {
+    const { loading, data } = useMeHeaderQuery();
+    const user = data?.me || undefined;
+
+    return (
+        <UserContext.Provider value={{
+            user,
+            loading
+        }}
+        >{children}</UserContext.Provider>
+    )
+}
+
+export function useUser() {
+    const context = React.useContext(UserContext)
+    if (context === undefined) {
+        throw new Error('useUser must be used within a UserProvider')
+    }
+    return context
+}
+
+export default UserContext;

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -18,5 +18,12 @@
     "sign out": "Sign out",
     "logged in as": "Logged in as",
     "show profile": "Show profile",
-    "failed": "Failed"
+    "failed": "Failed",
+    "update": "Update",
+    "save": "Save",
+    "upload": "Upload",
+    "swedish": "Swedish",
+    "english": "English",
+    "notAuthenticated": "Not Authenticated",
+    "edit": "Edit"
 }

--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -25,5 +25,6 @@
     "swedish": "Swedish",
     "english": "English",
     "notAuthenticated": "Not Authenticated",
-    "edit": "Edit"
+    "edit": "Edit",
+    "delete": "Delete"
 }

--- a/frontend/public/locales/en/news.json
+++ b/frontend/public/locales/en/news.json
@@ -2,7 +2,7 @@
     "loadingNews": "Fetching News...",
     "failedLoadingNews": "Failed to fetch news",
     "articleError": "Article broken",
-    "loadingArticle": "Laddar artikel...",
+    "loadingArticle": "Loading article...",
     "header": "Header",
     "edit_saved": "Edit saved",
     "write": "Write",

--- a/frontend/public/locales/en/news.json
+++ b/frontend/public/locales/en/news.json
@@ -10,5 +10,6 @@
     "uploadingImage": "Uploading image...",
     "pasteDropSelect": "Attach files by dragging & dropping, selecting or pasting them.",
     "editArticle": "Edit article",
-    "createArticle": "Create article"
+    "createArticle": "Create article",
+    "areYouSureYouWantToDeleteThisArticle": "Are you sure you want to delete this article?"
 }

--- a/frontend/public/locales/en/news.json
+++ b/frontend/public/locales/en/news.json
@@ -2,6 +2,13 @@
     "loadingNews": "Fetching News...",
     "failedLoadingNews": "Failed to fetch news",
     "articleError": "Article broken",
-    "loadingArticle": "Laddar artikel..."
-    
+    "loadingArticle": "Laddar artikel...",
+    "header": "Header",
+    "edit_saved": "Edit saved",
+    "write": "Write",
+    "preview": "Preview",
+    "uploadingImage": "Uploading image...",
+    "pasteDropSelect": "Attach files by dragging & dropping, selecting or pasting them.",
+    "editArticle": "Edit article",
+    "createArticle": "Create article"
 }

--- a/frontend/public/locales/sv/common.json
+++ b/frontend/public/locales/sv/common.json
@@ -18,5 +18,12 @@
     "sign out": "Logga ut",
     "logged in as": "Inloggad som",
     "show profile": "Visa profil",
-    "failed": "Misslyckades"
+    "failed": "Misslyckades",
+    "update": "Uppdatera",
+    "save": "Spara",
+    "upload": "Ladda up",
+    "swedish": "Svenska",
+    "english": "Engelska",
+    "notAuthenticated": "Inte inloggad",
+    "edit": "Redigera"
 }

--- a/frontend/public/locales/sv/common.json
+++ b/frontend/public/locales/sv/common.json
@@ -25,5 +25,6 @@
     "swedish": "Svenska",
     "english": "Engelska",
     "notAuthenticated": "Inte inloggad",
-    "edit": "Redigera"
+    "edit": "Redigera",
+    "delete": "Radera"
 }

--- a/frontend/public/locales/sv/news.json
+++ b/frontend/public/locales/sv/news.json
@@ -2,7 +2,7 @@
     "loadingNews": "Laddar nyheter...",
     "failedLoadingNews": "Misslyckades med att hämta nyheterna",
     "articleError": "Article broken",
-    "loadingArticle": "Loading article...",
+    "loadingArticle": "Laddar artikel...",
     "header": "Rubrik",
     "edit_saved": "Ändringar sparade",
     "write": "Skriv",

--- a/frontend/public/locales/sv/news.json
+++ b/frontend/public/locales/sv/news.json
@@ -10,5 +10,6 @@
     "uploadingImage": "Laddar upp bild...",
     "pasteDropSelect": "Bifoga filer genom att dra och släppa dem eller klistra in dem.",
     "editArticle": "Redigera artikel",
-    "createArticle": "Skapa artikel"
+    "createArticle": "Skapa artikel",
+    "areYouSureYouWantToDeleteThisArticle": "Är du säker på att du vill ta bort artikeln?"
 }

--- a/frontend/public/locales/sv/news.json
+++ b/frontend/public/locales/sv/news.json
@@ -2,5 +2,13 @@
     "loadingNews": "Laddar nyheter...",
     "failedLoadingNews": "Misslyckades med att hämta nyheterna",
     "articleError": "Article broken",
-    "loadingArticle": "Loading article..."
+    "loadingArticle": "Loading article...",
+    "header": "Rubrik",
+    "edit_saved": "Ändringar sparade",
+    "write": "Skriv",
+    "preview": "Förhandsvisa",
+    "uploadingImage": "Laddar upp bild...",
+    "pasteDropSelect": "Bifoga filer genom att dra och släppa dem eller klistra in dem.",
+    "editArticle": "Redigera artikel",
+    "createArticle": "Skapa artikel"
 }

--- a/frontend/routes.ts
+++ b/frontend/routes.ts
@@ -3,6 +3,8 @@ const routes = {
     article: articleId => `/news/article/${articleId}`,
     member: memberId => `/members/${memberId}`,
     news: '/news',
+    editArticle: articleId => `/news/article/edit/${articleId}`,
+    createArticle: '/news/article/create',
     documents: '#documents',
     statues: '#statues',
     regulations: '#reglemente',

--- a/frontend/styles/articleEditorPageStyles.tsx
+++ b/frontend/styles/articleEditorPageStyles.tsx
@@ -3,6 +3,9 @@ import { makeStyles } from '@material-ui/core/styles';
 const articleEditorPageStyles = makeStyles(theme => ({
     container:{
         padding: "1em",
+    },
+    removeButton: {
+        marginTop: theme.spacing(2)
     } 
 }))
 

--- a/frontend/styles/articleEditorPageStyles.tsx
+++ b/frontend/styles/articleEditorPageStyles.tsx
@@ -1,0 +1,9 @@
+import { makeStyles } from '@material-ui/core/styles';
+
+const articleEditorPageStyles = makeStyles(theme => ({
+    container:{
+        padding: "1em",
+    } 
+}))
+
+export default articleEditorPageStyles;


### PR DESCRIPTION
Adds pages for creating and editing news, See attached images. The file upload currently does nothing and is subject to change since no file server exists yet. Also implements a user provider to easily access the currently logged-in user across the app.

Closes #73 

![screencapture-localhost-3000-news-article-edit-98-2021-05-05-01_59_35](https://user-images.githubusercontent.com/7382555/117083766-ba9afc00-ad45-11eb-9c86-c52512e40218.png)
![screencapture-localhost-3000-news-article-create-2021-05-05-01_59_56](https://user-images.githubusercontent.com/7382555/117083772-bc64bf80-ad45-11eb-99f6-e695e26515ca.png)
![screencapture-localhost-3000-news-article-create-2021-05-05-02_00_18](https://user-images.githubusercontent.com/7382555/117083767-bbcc2900-ad45-11eb-8701-b4e2c8a85b13.png)



