### PR TITLE
Change DateTime pickers to use mui's own DateTimePicker

### DIFF
--- a/frontend/components/AddAccessPolicyForm.tsx
+++ b/frontend/components/AddAccessPolicyForm.tsx
@@ -93,16 +93,14 @@ export default function AddAccessPolicyForm({
               style={{ marginTop: '1rem' }}
             >
               <DateTimePicker
-                dateTime={startDateTime}
-                setDateTime={setStartDateTime}
-                timeLabel={t('policy:startTime')}
-                dateLabel={t('policy:startDate')}
+                value={startDateTime}
+                onChange={setStartDateTime}
+                label={t('policy:startTime')}
               />
               <DateTimePicker
-                dateTime={endDateTime}
-                setDateTime={setEndDateTime}
-                timeLabel={t('policy:endTime')}
-                dateLabel={t('policy:endDate')}
+                value={endDateTime}
+                onChange={setEndDateTime}
+                label={t('policy:endTime')}
               />
             </Stack>
           )}

--- a/frontend/components/BookingFilter/index.tsx
+++ b/frontend/components/BookingFilter/index.tsx
@@ -13,10 +13,9 @@ export default function BookingFilter({ to, onToChange }: BookingFilterProps) {
 
   return (
     <DateTimePicker
-      dateTime={to}
-      setDateTime={onToChange}
-      timeLabel={t('booking:endTime')}
-      dateLabel={t('booking:endDate')}
+      value={to}
+      onChange={onToChange}
+      label={t('booking:endTime')}
     />
   );
 }

--- a/frontend/components/BookingForm/index.tsx
+++ b/frontend/components/BookingForm/index.tsx
@@ -86,16 +86,14 @@ export default function BookingForm({ onSubmit }: BookingFormProps) {
         spacing={3}
       >
         <DateTimePicker
-          dateTime={startDateTime}
-          setDateTime={setStartDateTime}
-          timeLabel={t('booking:startTime')}
-          dateLabel={t('booking:startDate')}
+          value={startDateTime}
+          onChange={setStartDateTime}
+          label={t('booking:startTime')}
         />
         <DateTimePicker
-          dateTime={endDateTime}
-          setDateTime={setEndDateTime}
-          timeLabel={t('booking:endTime')}
-          dateLabel={t('booking:endDate')}
+          value={endDateTime}
+          onChange={setEndDateTime}
+          label={t('booking:endTime')}
         />
       </Stack>
 

--- a/frontend/components/Calendar/EventEditor.tsx
+++ b/frontend/components/Calendar/EventEditor.tsx
@@ -255,16 +255,16 @@ export default function EditEvent({ onSubmit, eventQuery }: BookingFormProps) {
       />
       <Stack direction={large ? 'row' : 'column'} spacing={3}>
         <DateTimePicker
-          dateTime={startDateTime}
-          setDateTime={setStartDateTime}
-          timeLabel={t('booking:startTime')}
-          dateLabel={t('booking:startDate')}
+          value={startDateTime}
+          onChange={setStartDateTime}
+          label={t('booking:startTime')}
+          InputProps={{ fullWidth: true }}
         />
         <DateTimePicker
-          dateTime={endDateTime}
-          setDateTime={setEndDateTime}
-          timeLabel={t('booking:endTime')}
-          dateLabel={t('booking:endDate')}
+          value={endDateTime}
+          onChange={setEndDateTime}
+          label={t('booking:endTime')}
+          InputProps={{ fullWidth: true }}
         />
       </Stack>
 

--- a/frontend/components/DateTimePicker/index.tsx
+++ b/frontend/components/DateTimePicker/index.tsx
@@ -1,46 +1,24 @@
-import React from 'react';
 import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
+import { DateTimePicker as MuiDateTimePicker } from '@mui/x-date-pickers/DateTimePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import { useTranslation } from 'next-i18next';
-import { DatePicker } from '@mui/x-date-pickers/DatePicker';
-import { TimePicker } from '@mui/x-date-pickers/TimePicker';
-import { Stack, TextField } from '@mui/material';
-import { DateTime } from 'luxon';
+import React from 'react';
 
-type DateTimePickerProps = {
-  dateTime: DateTime;
-  timeLabel?: string;
-  dateLabel?: string;
-  setDateTime: (string) => void;
-};
+import { TextField } from '@mui/material';
 
-export default function DateTimePicker({
-  dateTime,
-  setDateTime,
-  timeLabel,
-  dateLabel,
-}: DateTimePickerProps) {
+type DateTimePickerProps = Omit<React.ComponentProps<typeof MuiDateTimePicker>, 'renderInput'>;
+
+export default function DateTimePicker(props: DateTimePickerProps) {
   const { i18n } = useTranslation(['common']);
   return (
     <LocalizationProvider dateAdapter={AdapterLuxon} locale={i18n.language}>
-      <Stack spacing={2} direction="row">
-        <DatePicker
-          label={dateLabel}
-          value={dateTime}
-          onChange={(newDate) => {
-            setDateTime(newDate);
-          }}
-          renderInput={(params) => <TextField {...params} />}
-        />
-        <TimePicker
-          label={timeLabel}
-          value={dateTime}
-          onChange={(newTime) => {
-            setDateTime(newTime);
-          }}
-          renderInput={(params) => <TextField {...params} />}
-        />
-      </Stack>
+      <MuiDateTimePicker
+        renderInput={(p) => <TextField fullWidth {...p} />}
+        {...props}
+        InputProps={{
+          fullWidth: true,
+        }}
+      />
     </LocalizationProvider>
   );
 }


### PR DESCRIPTION
Closes #641 

This PR replaces all DateTimePickers with MUI's own DateTimePicker. Previously it was one picker for date and one for time. This worked but did lead to bugs, for example the one above. Personally, I also like it being in one picker. If we for some reason WANT to have two separate inputs, please comment below and I'll look into reverting but just fixing the bug.