### PR TITLE
721 make tag colors theme specific

### DIFF
--- a/frontend/components/Tag.tsx
+++ b/frontend/components/Tag.tsx
@@ -2,12 +2,20 @@ import Restaurant from '@mui/icons-material/Restaurant';
 import Business from '@mui/icons-material/Business';
 import PriorityHigh from '@mui/icons-material/PriorityHigh';
 import Groups from '@mui/icons-material/Groups';
-import { Chip } from '@mui/material';
+import { Chip, useTheme } from '@mui/material';
 import React from 'react';
 import { useTranslation } from 'next-i18next';
 import Link from '~/components/Link';
 import selectTranslation from '~/functions/selectTranslation';
 import { Tag as TagType } from '~/generated/graphql';
+import { colorAppropiator } from '~/functions/colorFunctions';
+
+export const tagIcons = {
+  Restaurant,
+  Business,
+  PriorityHigh,
+  Groups,
+};
 
 type Props = {
   tag: TagType;

--- a/frontend/components/Tag.tsx
+++ b/frontend/components/Tag.tsx
@@ -1,6 +1,10 @@
-import { Chip } from '@mui/material';
-import { useTranslation } from 'next-i18next';
+import Restaurant from '@mui/icons-material/Restaurant';
+import Business from '@mui/icons-material/Business';
+import PriorityHigh from '@mui/icons-material/PriorityHigh';
+import Groups from '@mui/icons-material/Groups';
+import { Chip, hslToRgb } from '@mui/material';
 import React from 'react';
+import { useTranslation } from 'next-i18next';
 import Link from '~/components/Link';
 import selectTranslation from '~/functions/selectTranslation';
 import { Tag as TagType } from '~/generated/graphql';
@@ -11,14 +15,29 @@ type Props = {
 
 function TagComponent({ tag, ...chipProps }: Props) {
   const { i18n } = useTranslation('common');
+  const theme = useTheme();
+  const darkColor = colorAppropiator(tag.color, 'black');
+  const lightColor = colorAppropiator(tag.color, 'white');
+  const renderTagIcon = (iconName?: string, color?: string) => {
+    if (!iconName || !tagIcons[iconName]) return undefined;
+    const Comp = tagIcons[iconName];
+    return <Comp fontSize="small" style={color ? { color } : undefined} />;
+  };
   return (
     <Chip
+      icon={theme.palette.mode === 'dark' ? renderTagIcon(tag.icon, darkColor) : renderTagIcon(tag.icon, lightColor)}
       label={selectTranslation(i18n, tag.name, tag.nameEn)}
       size="small"
       variant="outlined"
-      style={{
-        color: tag.color,
-        borderColor: tag.color,
+      style={theme.palette.mode === 'dark' ? {
+        color: darkColor,
+        borderColor: darkColor,
+        padding: 8,
+        margin: 4,
+        cursor: 'pointer',
+      } : {
+        color: lightColor,
+        borderColor: lightColor,
         padding: 8,
         margin: 4,
         cursor: 'pointer',

--- a/frontend/components/Tag.tsx
+++ b/frontend/components/Tag.tsx
@@ -2,7 +2,7 @@ import Restaurant from '@mui/icons-material/Restaurant';
 import Business from '@mui/icons-material/Business';
 import PriorityHigh from '@mui/icons-material/PriorityHigh';
 import Groups from '@mui/icons-material/Groups';
-import { Chip, hslToRgb } from '@mui/material';
+import { Chip } from '@mui/material';
 import React from 'react';
 import { useTranslation } from 'next-i18next';
 import Link from '~/components/Link';

--- a/frontend/components/Tag.tsx
+++ b/frontend/components/Tag.tsx
@@ -16,8 +16,8 @@ type Props = {
 function TagComponent({ tag, ...chipProps }: Props) {
   const { i18n } = useTranslation('common');
   const theme = useTheme();
-  const darkColor = colorAppropiator(tag.color, 'black');
-  const lightColor = colorAppropiator(tag.color, 'white');
+  const darkColor = colorAppropiator('rgb(255,255,0)', 'black');
+  const lightColor = colorAppropiator('rgb(255,255,0)', 'white');
   const renderTagIcon = (iconName?: string, color?: string) => {
     if (!iconName || !tagIcons[iconName]) return undefined;
     const Comp = tagIcons[iconName];

--- a/frontend/components/Tag.tsx
+++ b/frontend/components/Tag.tsx
@@ -16,8 +16,8 @@ type Props = {
 function TagComponent({ tag, ...chipProps }: Props) {
   const { i18n } = useTranslation('common');
   const theme = useTheme();
-  const darkColor = colorAppropiator('rgb(255,255,0)', 'black');
-  const lightColor = colorAppropiator('rgb(255,255,0)', 'white');
+  const darkColor = colorAppropiator(tag.color, 'black');
+  const lightColor = colorAppropiator(tag.color, 'white');
   const renderTagIcon = (iconName?: string, color?: string) => {
     if (!iconName || !tagIcons[iconName]) return undefined;
     const Comp = tagIcons[iconName];

--- a/frontend/components/Tag.tsx
+++ b/frontend/components/Tag.tsx
@@ -10,12 +10,6 @@ import selectTranslation from '~/functions/selectTranslation';
 import { Tag as TagType } from '~/generated/graphql';
 import { colorAppropiator } from '~/functions/colorFunctions';
 
-export const tagIcons = {
-  Restaurant,
-  Business,
-  PriorityHigh,
-  Groups,
-};
 
 type Props = {
   tag: TagType;
@@ -26,14 +20,8 @@ function TagComponent({ tag, ...chipProps }: Props) {
   const theme = useTheme();
   const darkColor = colorAppropiator(tag.color, 'black');
   const lightColor = colorAppropiator(tag.color, 'white');
-  const renderTagIcon = (iconName?: string, color?: string) => {
-    if (!iconName || !tagIcons[iconName]) return undefined;
-    const Comp = tagIcons[iconName];
-    return <Comp fontSize="small" style={color ? { color } : undefined} />;
-  };
   return (
     <Chip
-      icon={theme.palette.mode === 'dark' ? renderTagIcon(tag.icon, darkColor) : renderTagIcon(tag.icon, lightColor)}
       label={selectTranslation(i18n, tag.name, tag.nameEn)}
       size="small"
       variant="outlined"

--- a/frontend/components/Tag.tsx
+++ b/frontend/components/Tag.tsx
@@ -1,7 +1,3 @@
-import Restaurant from '@mui/icons-material/Restaurant';
-import Business from '@mui/icons-material/Business';
-import PriorityHigh from '@mui/icons-material/PriorityHigh';
-import Groups from '@mui/icons-material/Groups';
 import { Chip, useTheme } from '@mui/material';
 import React from 'react';
 import { useTranslation } from 'next-i18next';
@@ -9,7 +5,6 @@ import Link from '~/components/Link';
 import selectTranslation from '~/functions/selectTranslation';
 import { Tag as TagType } from '~/generated/graphql';
 import { colorAppropiator } from '~/functions/colorFunctions';
-
 
 type Props = {
   tag: TagType;
@@ -25,19 +20,23 @@ function TagComponent({ tag, ...chipProps }: Props) {
       label={selectTranslation(i18n, tag.name, tag.nameEn)}
       size="small"
       variant="outlined"
-      style={theme.palette.mode === 'dark' ? {
-        color: darkColor,
-        borderColor: darkColor,
-        padding: 8,
-        margin: 4,
-        cursor: 'pointer',
-      } : {
-        color: lightColor,
-        borderColor: lightColor,
-        padding: 8,
-        margin: 4,
-        cursor: 'pointer',
-      }}
+      style={
+        theme.palette.mode === 'dark'
+          ? {
+            color: darkColor,
+            borderColor: darkColor,
+            padding: 8,
+            margin: 4,
+            cursor: 'pointer',
+          }
+          : {
+            color: lightColor,
+            borderColor: lightColor,
+            padding: 8,
+            margin: 4,
+            cursor: 'pointer',
+          }
+      }
       {...chipProps}
     />
   );
@@ -55,9 +54,7 @@ function Tag({ tag, ...chipProps }: Props) {
       </Link>
     );
   }
-  return (
-    <TagComponent tag={tag} {...chipProps} />
-  );
+  return <TagComponent tag={tag} {...chipProps} />;
 }
 
 export default Tag;

--- a/frontend/functions/colorFunctions.ts
+++ b/frontend/functions/colorFunctions.ts
@@ -1,37 +1,53 @@
 import { hexToRgb, hslToRgb } from "@mui/system";
 
 let colorMap = new Map<string, string>([
-    ["white" , "rgb(255,255,255)"],
-    ["black" , "rgb(0,0,0)"], 
+    ["white", "rgb(255,255,255)"],
+    ["black", "rgb(0,0,0)"], 
+    ["yellow", "rgb(255,255,0)"],
     //add more colors to account for all predetermined coluours here
 ]);
 
 export function colorAppropiator(foreground : string, background : string){
     const fRGB = colorParser(foreground);
-    const bRGP = colorParser(background);
-    const contrast = colorContrast(fRGB, bRGP);
+    const bRGB = colorParser(background);
     
+    console.log(colorContrast(fRGB, bRGB))
+    console.log(colorAdjust(fRGB, bRGB))
+    console.log(colorContrast(colorAdjust(fRGB, bRGB), bRGB))
+    return colorAdjust(fRGB, bRGB)
+}
+
+
+export function colorAdjust(foreground: string,  background: string){
+    const contrast = colorContrast(foreground, background);
     if(contrast >= 4.5){
-        return fRGB;
+        return foreground
     }
     else{
-        return colorAdjust(fRGB, contrast);
-    }
-}
-export function colorAdjust(color: string, contrast : number){
-    const values = rgbValues(color).map(a => (a * 4.5 / contrast) % 255);
-    const adjustedcolor = `rgb(${values[0]}, ${values[1]}, ${values[2]})`;
-    return adjustedcolor;
-}
+        let newLum = 0
+        let m = 0
+        let values = [];
+        if(luminance(foreground) > luminance(background)){
+            newLum = 4.5*(luminance(background) + 0.05) - 0.05;
+        }
+        else{
+           newLum = (luminance(background) + 0.05)/4.5 -0.05
+        }
+        return parseLum(newLum, rgbValues(foreground));
+        values = rgbValues(foreground).map(a => Math.min((a * contrastMultiplier(m, luminance(foreground))), 255));
+        console.log(contrastMultiplier(m, luminance(foreground)));
+        const adjustedcolor = `rgb(${values[0]}, ${values[1]}, ${values[2]})`;
+        return adjustedcolor;
+}}
 
 export function colorParser(color : string){
     if(color[0] ==  '#'){
         return hexToRgb(color);
     }
-    else if(color.toLowerCase().substring(0,2) == 'hsb'){
+    else if(color.toLowerCase().substring(0,3) == 'hsb'){
         return hslToRgb(color);
     }
-    else if(color.toLowerCase().substring (0,2) == 'rgb'){
+    else if(color.toLowerCase().substring(0,3) == 'rgb'){
         return color;
     }
     else if(colorMap.has(color.toLowerCase())){
@@ -40,12 +56,11 @@ export function colorParser(color : string){
     else{
         return "rgb(255,255,255)"
     }
-
 }
 
 function luminance(color :  string){
     const values = rgbValues(color);
-    return values[0] * 0.2126 + values[1] * 0.7152 + values[2] * 0.0722;
+    return values[0]/255 * 0.2126 + values[1]/255 * 0.7152 + values[2]/255 * 0.0722;
 }
 
 function rgbValues(color : string){
@@ -55,11 +70,38 @@ function rgbValues(color : string){
 function colorContrast(c1 : string, c2 : string){
     const l1 = luminance(c1);
     const l2 = luminance(c2);
-    if(l1 > l2){
-        return (l1 + 0.05) / (l2 + 0.05);
-    }
-    else{
-        return (l2 +0.05) / (l1 + 0.05);
+    return (Math.max(l1,l2) + 0.05) / (Math.min(l1,l2) + 0.05)
+}
+
+function contrastMultiplier(m: number, luminance: number){
+    return m + 0.05 * ((m - 1) / luminance)
+}
+
+function parseLum(lum: number, rgbValues: Array<number>){
+    let r = rgbValues[0];
+    let g = rgbValues[1];
+    let b = rgbValues[2];
+    if(r + g + b == 0){
+        r=1;
+        g=1;
+        b=1;
     }
 
+    let nonZero = [];
+    for (let i = 0; i < [r,g,b].length; i++){
+        if ([r,g,b][i] != 0){
+            nonZero = [[r,g,b][i], i]
+        }
+    }
+    const ratios = [r,g,b].map(a => a/nonZero[0]);
+    const divider = (0.2126*ratios[0] + 0.7152*ratios[1] + 0.0722*ratios[2])
+
+    let r2 = lum/divider * 255 * ratios[0] * ratios[nonZero[1]];
+    let b2 = lum/divider * 255 * ratios[1] * ratios[nonZero[1]];
+    let c2 = lum/divider * 255 * ratios[2] * ratios[nonZero[1]];
+
+    const newValues = [r2,b2,c2]
+    newValues[nonZero[1]] = newValues[nonZero[1]]/ratios[nonZero[1]]
+
+    return `rgb(${newValues[0]},${newValues[1]},${newValues[2]})`
 }

--- a/frontend/functions/colorFunctions.ts
+++ b/frontend/functions/colorFunctions.ts
@@ -1,99 +1,83 @@
 import { hexToRgb, hslToRgb } from '@mui/system';
 
 const colorMap = new Map<string, string>([
-	['white', 'rgb(255,255,255)'],
-  ['black', 'rgb(0,0,0)'], 
+  ['white', 'rgb(255,255,255)'],
+  ['black', 'rgb(0,0,0)'],
   ['yellow', 'rgb(255,255,0)'],
-	 //add more colors to account for all predetermined coluours here
 ]);
 
-export function colorAppropiator(foreground : string, background : string){
-	const fRGB = colorParser(foreground);
-	const bRGB = colorParser(background);
-			
-	console.log(colorContrast(fRGB, bRGB))
-	console.log(colorAdjust(fRGB, bRGB))
-	console.log(colorContrast(colorAdjust(fRGB, bRGB), bRGB))
-	return colorAdjust(fRGB, bRGB)
+function rgbValues(color : string) {
+  return color.split(/[()]+/)[1].split(',').map((a) => parseInt(a, 10));
 }
 
-
-export function colorAdjust(foreground: string,  background: string){
-const contrast = colorContrast(foreground, background);
-	if(contrast >= 4.5){
-    return foreground
-}
-	else{
-  	let newLum = 0
-    let m = 0
-    let values = [];
-    if(luminance(foreground) > luminance(background)){
-      newLum = 4.5*(luminance(background) + 0.05) - 0.05;
-    }
-    else{
-      newLum = (luminance(background) + 0.05)/4.5 -0.05
-    }
-    return parseLum(newLum, rgbValues(foreground));
-}}
-
-export function colorParser(color : string){
-  if(color[0] ==  '#'){
-      return hexToRgb(color);
-    }
-  else if(color.toLowerCase().substring(0,3) == 'hsb'){
-      return hslToRgb(color);
-    }
-  else if(color.toLowerCase().substring(0,3) == 'rgb'){
-    return color;
-    }
-  else if(colorMap.has(color.toLowerCase())){
-    return colorMap.get(color);
-  }
-  else{
-    return 'rgb(255,255,255)'
-  }
-}
-
-function luminance(color :  string){
+function luminance(color : string) {
   const values = rgbValues(color);
-  return values[0]/255 * 0.2126 + values[1]/255 * 0.7152 + values[2]/255 * 0.0722;
+  return ((values[0] / 255) * 0.2126) + ((values[1] / 255) * 0.7152) + ((values[2] / 255) * 0.0722);
 }
 
-function rgbValues(color : string){
-  return color.split(/[()]+/)[1].split(',').map(a => parseInt(a));
-}
-
-function colorContrast(c1 : string, c2 : string){
+function colorContrast(c1 : string, c2 : string) {
   const l1 = luminance(c1);
   const l2 = luminance(c2);
-  return (Math.max(l1,l2) + 0.05) / (Math.min(l1,l2) + 0.05)
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
 }
 
-function contrastMultiplier(m: number, luminance: number){
-    return m + 0.05 * ((m - 1) / luminance)
+export function colorParser(color : string) {
+  if (color[0] === '#') {
+    return hexToRgb(color);
+  }
+  if (color.toLowerCase().substring(0, 3) === 'hsb') {
+    return hslToRgb(color);
+  }
+  if (color.toLowerCase().substring(0, 3) === 'rgb') {
+    return color;
+  }
+  if (colorMap.has(color.toLowerCase())) {
+    return colorMap.get(color);
+  }
+  return 'rgb(255,255,255)';
 }
 
-function parseLum(lum: number, rgbValues: Array<number>){
-  let r = rgbValues[0];
-  let g = rgbValues[1];
-  let b = rgbValues[2];
-  if(r + g + b == 0){
-    r=1;
-    g=1;
-    b=1;
+function parseLum(lum: number, rgbList: Array<number>) {
+  let r = rgbList[0];
+  let g = rgbList[1];
+  let b = rgbList[2];
+  if (r + g + b === 0) {
+    r = 1;
+    g = 1;
+    b = 1;
   }
   let nonZero = [];
-  for (let i = 0; i < [r,g,b].length; i++){
-    if ([r,g,b][i] != 0){
-      nonZero = [[r,g,b][i], i]
+  for (let i = 0; i < [r, g, b].length; i += 1) {
+    if ([r, g, b][i] !== 0) {
+      nonZero = [[r, g, b][i], i];
     }
-	}
-  const ratios = [r,g,b].map(a => a/nonZero[0]);
-  const divider = (0.2126*ratios[0] + 0.7152*ratios[1] + 0.0722*ratios[2])
-  let r2 = lum/divider * 255 * ratios[0] * ratios[nonZero[1]];
-  let b2 = lum/divider * 255 * ratios[1] * ratios[nonZero[1]];
-  let c2 = lum/divider * 255 * ratios[2] * ratios[nonZero[1]];
-  const newValues = [r2,b2,c2]
-  newValues[nonZero[1]] = newValues[nonZero[1]]/ratios[nonZero[1]]
-  return `rgb(${newValues[0]},${newValues[1]},${newValues[2]})`
+  }
+  const ratios = [r, g, b].map((a) => a / nonZero[0]);
+  const divider = (0.2126 * ratios[0] + 0.7152 * ratios[1] + 0.0722 * ratios[2]);
+  const r2 = (lum / divider) * 255 * ratios[0] * ratios[nonZero[1]];
+  const b2 = (lum / divider) * 255 * ratios[1] * ratios[nonZero[1]];
+  const c2 = (lum / divider) * 255 * ratios[2] * ratios[nonZero[1]];
+  const newValues = [r2, b2, c2];
+  newValues[nonZero[1]] /= ratios[nonZero[1]];
+  return `rgb(${newValues[0]},${newValues[1]},${newValues[2]})`;
+}
+
+export function colorAdjust(foreground: string, background: string) {
+  const contrast = colorContrast(foreground, background);
+  if (contrast >= 4.5) {
+    return foreground;
+  }
+  let newLum = 0;
+  if (luminance(foreground) > luminance(background)) {
+    newLum = 4.5 * (luminance(background) + 0.05) - 0.05;
+  } else {
+    newLum = (luminance(background) + 0.05) / 4.5 - 0.05;
+  }
+  return parseLum(newLum, rgbValues(foreground));
+}
+
+export function colorAppropiator(foreground : string, background : string) {
+  const fRGB = colorParser(foreground);
+  const bRGB = colorParser(background);
+  return colorAdjust(fRGB, bRGB);
 }

--- a/frontend/functions/colorFunctions.ts
+++ b/frontend/functions/colorFunctions.ts
@@ -1,0 +1,65 @@
+import { hexToRgb, hslToRgb } from "@mui/system";
+
+let colorMap = new Map<string, string>([
+    ["white" , "rgb(255,255,255)"],
+    ["black" , "rgb(0,0,0)"], 
+    //add more colors to account for all predetermined coluours here
+]);
+
+export function colorAppropiator(foreground : string, background : string){
+    const fRGB = colorParser(foreground);
+    const bRGP = colorParser(background);
+    const contrast = colorContrast(fRGB, bRGP);
+    
+    if(contrast >= 4.5){
+        return fRGB;
+    }
+    else{
+        return colorAdjust(fRGB, contrast);
+    }
+}
+export function colorAdjust(color: string, contrast : number){
+    const values = rgbValues(color).map(a => (a * 4.5 / contrast) % 255);
+    const adjustedcolor = `rgb(${values[0]}, ${values[1]}, ${values[2]})`;
+    return adjustedcolor;
+}
+
+export function colorParser(color : string){
+    if(color[0] ==  '#'){
+        return hexToRgb(color);
+    }
+    else if(color.toLowerCase().substring(0,2) == 'hsb'){
+        return hslToRgb(color);
+    }
+    else if(color.toLowerCase().substring (0,2) == 'rgb'){
+        return color;
+    }
+    else if(colorMap.has(color.toLowerCase())){
+        return colorMap.get(color);
+    }
+    else{
+        return "rgb(255,255,255)"
+    }
+
+}
+
+function luminance(color :  string){
+    const values = rgbValues(color);
+    return values[0] * 0.2126 + values[1] * 0.7152 + values[2] * 0.0722;
+}
+
+function rgbValues(color : string){
+    return color.split(/[()]+/)[1].split(",").map(a => parseInt(a));
+}
+
+function colorContrast(c1 : string, c2 : string){
+    const l1 = luminance(c1);
+    const l2 = luminance(c2);
+    if(l1 > l2){
+        return (l1 + 0.05) / (l2 + 0.05);
+    }
+    else{
+        return (l2 +0.05) / (l1 + 0.05);
+    }
+
+}

--- a/frontend/functions/colorFunctions.ts
+++ b/frontend/functions/colorFunctions.ts
@@ -34,10 +34,6 @@ export function colorAdjust(foreground: string,  background: string){
            newLum = (luminance(background) + 0.05)/4.5 -0.05
         }
         return parseLum(newLum, rgbValues(foreground));
-        values = rgbValues(foreground).map(a => Math.min((a * contrastMultiplier(m, luminance(foreground))), 255));
-        console.log(contrastMultiplier(m, luminance(foreground)));
-        const adjustedcolor = `rgb(${values[0]}, ${values[1]}, ${values[2]})`;
-        return adjustedcolor;
 }}
 
 export function colorParser(color : string){

--- a/frontend/functions/colorFunctions.ts
+++ b/frontend/functions/colorFunctions.ts
@@ -1,72 +1,72 @@
-import { hexToRgb, hslToRgb } from "@mui/system";
+import { hexToRgb, hslToRgb } from '@mui/system';
 
-let colorMap = new Map<string, string>([
-    ["white", "rgb(255,255,255)"],
-    ["black", "rgb(0,0,0)"], 
-    ["yellow", "rgb(255,255,0)"],
-    //add more colors to account for all predetermined coluours here
+const colorMap = new Map<string, string>([
+	['white', 'rgb(255,255,255)'],
+  ['black', 'rgb(0,0,0)'], 
+  ['yellow', 'rgb(255,255,0)'],
+	 //add more colors to account for all predetermined coluours here
 ]);
 
 export function colorAppropiator(foreground : string, background : string){
-    const fRGB = colorParser(foreground);
-    const bRGB = colorParser(background);
-    
-    console.log(colorContrast(fRGB, bRGB))
-    console.log(colorAdjust(fRGB, bRGB))
-    console.log(colorContrast(colorAdjust(fRGB, bRGB), bRGB))
-    return colorAdjust(fRGB, bRGB)
+	const fRGB = colorParser(foreground);
+	const bRGB = colorParser(background);
+			
+	console.log(colorContrast(fRGB, bRGB))
+	console.log(colorAdjust(fRGB, bRGB))
+	console.log(colorContrast(colorAdjust(fRGB, bRGB), bRGB))
+	return colorAdjust(fRGB, bRGB)
 }
 
 
 export function colorAdjust(foreground: string,  background: string){
-    const contrast = colorContrast(foreground, background);
-    if(contrast >= 4.5){
-        return foreground
+const contrast = colorContrast(foreground, background);
+	if(contrast >= 4.5){
+    return foreground
+}
+	else{
+  	let newLum = 0
+    let m = 0
+    let values = [];
+    if(luminance(foreground) > luminance(background)){
+      newLum = 4.5*(luminance(background) + 0.05) - 0.05;
     }
     else{
-        let newLum = 0
-        let m = 0
-        let values = [];
-        if(luminance(foreground) > luminance(background)){
-            newLum = 4.5*(luminance(background) + 0.05) - 0.05;
-        }
-        else{
-           newLum = (luminance(background) + 0.05)/4.5 -0.05
-        }
-        return parseLum(newLum, rgbValues(foreground));
+      newLum = (luminance(background) + 0.05)/4.5 -0.05
+    }
+    return parseLum(newLum, rgbValues(foreground));
 }}
 
 export function colorParser(color : string){
-    if(color[0] ==  '#'){
-        return hexToRgb(color);
+  if(color[0] ==  '#'){
+      return hexToRgb(color);
     }
-    else if(color.toLowerCase().substring(0,3) == 'hsb'){
-        return hslToRgb(color);
+  else if(color.toLowerCase().substring(0,3) == 'hsb'){
+      return hslToRgb(color);
     }
-    else if(color.toLowerCase().substring(0,3) == 'rgb'){
-        return color;
+  else if(color.toLowerCase().substring(0,3) == 'rgb'){
+    return color;
     }
-    else if(colorMap.has(color.toLowerCase())){
-        return colorMap.get(color);
-    }
-    else{
-        return "rgb(255,255,255)"
-    }
+  else if(colorMap.has(color.toLowerCase())){
+    return colorMap.get(color);
+  }
+  else{
+    return 'rgb(255,255,255)'
+  }
 }
 
 function luminance(color :  string){
-    const values = rgbValues(color);
-    return values[0]/255 * 0.2126 + values[1]/255 * 0.7152 + values[2]/255 * 0.0722;
+  const values = rgbValues(color);
+  return values[0]/255 * 0.2126 + values[1]/255 * 0.7152 + values[2]/255 * 0.0722;
 }
 
 function rgbValues(color : string){
-    return color.split(/[()]+/)[1].split(",").map(a => parseInt(a));
+  return color.split(/[()]+/)[1].split(',').map(a => parseInt(a));
 }
 
 function colorContrast(c1 : string, c2 : string){
-    const l1 = luminance(c1);
-    const l2 = luminance(c2);
-    return (Math.max(l1,l2) + 0.05) / (Math.min(l1,l2) + 0.05)
+  const l1 = luminance(c1);
+  const l2 = luminance(c2);
+  return (Math.max(l1,l2) + 0.05) / (Math.min(l1,l2) + 0.05)
 }
 
 function contrastMultiplier(m: number, luminance: number){
@@ -74,30 +74,26 @@ function contrastMultiplier(m: number, luminance: number){
 }
 
 function parseLum(lum: number, rgbValues: Array<number>){
-    let r = rgbValues[0];
-    let g = rgbValues[1];
-    let b = rgbValues[2];
-    if(r + g + b == 0){
-        r=1;
-        g=1;
-        b=1;
+  let r = rgbValues[0];
+  let g = rgbValues[1];
+  let b = rgbValues[2];
+  if(r + g + b == 0){
+    r=1;
+    g=1;
+    b=1;
+  }
+  let nonZero = [];
+  for (let i = 0; i < [r,g,b].length; i++){
+    if ([r,g,b][i] != 0){
+      nonZero = [[r,g,b][i], i]
     }
-
-    let nonZero = [];
-    for (let i = 0; i < [r,g,b].length; i++){
-        if ([r,g,b][i] != 0){
-            nonZero = [[r,g,b][i], i]
-        }
-    }
-    const ratios = [r,g,b].map(a => a/nonZero[0]);
-    const divider = (0.2126*ratios[0] + 0.7152*ratios[1] + 0.0722*ratios[2])
-
-    let r2 = lum/divider * 255 * ratios[0] * ratios[nonZero[1]];
-    let b2 = lum/divider * 255 * ratios[1] * ratios[nonZero[1]];
-    let c2 = lum/divider * 255 * ratios[2] * ratios[nonZero[1]];
-
-    const newValues = [r2,b2,c2]
-    newValues[nonZero[1]] = newValues[nonZero[1]]/ratios[nonZero[1]]
-
-    return `rgb(${newValues[0]},${newValues[1]},${newValues[2]})`
+	}
+  const ratios = [r,g,b].map(a => a/nonZero[0]);
+  const divider = (0.2126*ratios[0] + 0.7152*ratios[1] + 0.0722*ratios[2])
+  let r2 = lum/divider * 255 * ratios[0] * ratios[nonZero[1]];
+  let b2 = lum/divider * 255 * ratios[1] * ratios[nonZero[1]];
+  let c2 = lum/divider * 255 * ratios[2] * ratios[nonZero[1]];
+  const newValues = [r2,b2,c2]
+  newValues[nonZero[1]] = newValues[nonZero[1]]/ratios[nonZero[1]]
+  return `rgb(${newValues[0]},${newValues[1]},${newValues[2]})`
 }

--- a/frontend/functions/colorFunctions.ts
+++ b/frontend/functions/colorFunctions.ts
@@ -6,22 +6,29 @@ const colorMap = new Map<string, string>([
   ['yellow', 'rgb(255,255,0)'],
 ]);
 
-function rgbValues(color : string) {
-  return color.split(/[()]+/)[1].split(',').map((a) => parseInt(a, 10));
+function rgbValues(color: string) {
+  return color
+    .split(/[()]+/)[1]
+    .split(',')
+    .map((a) => parseInt(a, 10));
 }
 
-function luminance(color : string) {
+function luminance(color: string) {
   const values = rgbValues(color);
-  return ((values[0] / 255) * 0.2126) + ((values[1] / 255) * 0.7152) + ((values[2] / 255) * 0.0722);
+  return (
+    (values[0] / 255) * 0.2126
+    + (values[1] / 255) * 0.7152
+    + (values[2] / 255) * 0.0722
+  );
 }
 
-function colorContrast(c1 : string, c2 : string) {
+function colorContrast(c1: string, c2: string) {
   const l1 = luminance(c1);
   const l2 = luminance(c2);
   return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
 }
 
-export function colorParser(color : string) {
+export function colorParser(color: string) {
   if (color[0] === '#') {
     return hexToRgb(color);
   }
@@ -53,7 +60,7 @@ function parseLum(lum: number, rgbList: Array<number>) {
     }
   }
   const ratios = [r, g, b].map((a) => a / nonZero[0]);
-  const divider = (0.2126 * ratios[0] + 0.7152 * ratios[1] + 0.0722 * ratios[2]);
+  const divider = 0.2126 * ratios[0] + 0.7152 * ratios[1] + 0.0722 * ratios[2];
   const r2 = (lum / divider) * 255 * ratios[0] * ratios[nonZero[1]];
   const b2 = (lum / divider) * 255 * ratios[1] * ratios[nonZero[1]];
   const c2 = (lum / divider) * 255 * ratios[2] * ratios[nonZero[1]];
@@ -76,7 +83,7 @@ export function colorAdjust(foreground: string, background: string) {
   return parseLum(newLum, rgbValues(foreground));
 }
 
-export function colorAppropiator(foreground : string, background : string) {
+export function colorAppropiator(foreground: string, background: string) {
   const fRGB = colorParser(foreground);
   const bRGB = colorParser(background);
   return colorAdjust(fRGB, bRGB);


### PR DESCRIPTION
Have implemented theme specific colors for tags. The parser still needs some improvements in edge cases where the tag color is specified with web colors but at the moment every tag should at least be readable in both mode while still retaining its colorful identity