### PR TITLE
🌐 Change "passed events" to "past events" in the UI

### DIFF
--- a/frontend/public/locales/en/common.json
+++ b/frontend/public/locales/en/common.json
@@ -69,7 +69,7 @@
   "mailAlias": "Mail alias",
   "markdownsAdmin": "Markdowns admin",
   "upcomingEvents": "Upcoming events",
-  "passedEvents": "Passed events",
+  "passedEvents": "Past events",
   "policy": "Policy",
   "policies": "Policies",
   "search": "Search",


### PR DESCRIPTION
The word "passed" as an adjective does not mean the same as "past"[^1][^2]. This PR only changes parts visually for the users, not the terminology used internally since this could have unforeseen consequences with routes such as `/events/passed`. 

WDYT?

[^1]: https://www.merriam-webster.com/dictionary/passed
[^2]: https://www.merriam-webster.com/dictionary/past

PS. These changes are *untested*, but should have no big impact. 