### PR TITLE
:bug: Fix login errors

### DIFF
--- a/frontend/apolloClient.ts
+++ b/frontend/apolloClient.ts
@@ -12,26 +12,22 @@ import merge from 'deepmerge';
 import isEqual from 'lodash/isEqual';
 import isServer from './functions/isServer';
 
-export const createApolloServerClient = async () => {
-  const httpLink = createHttpLink({
-    uri: process.env.NEXT_PUBLIC_GRAPHQL_ADDRESS,
-  });
-  return new ApolloClient({
-    ssrMode: true,
-    link: httpLink,
-    cache: new InMemoryCache(),
-    defaultOptions: {
-      query: {
-        errorPolicy: 'all',
-      },
+const httpLink = createHttpLink({
+  uri: process.env.NEXT_PUBLIC_GRAPHQL_ADDRESS,
+});
+
+export const createApolloServerClient = async () => new ApolloClient({
+  ssrMode: true,
+  link: httpLink,
+  cache: new InMemoryCache(),
+  defaultOptions: {
+    query: {
+      errorPolicy: 'all',
     },
-  });
-};
+  },
+});
 
 export const createApolloClient = (session?: Session) => {
-  const httpLink = createHttpLink({
-    uri: process.env.NEXT_PUBLIC_GRAPHQL_ADDRESS,
-  });
   const authLink = setContext((_, { headers }) => ({
     headers: {
       ...headers,

--- a/frontend/components/Header/AuthenticationStatus.tsx
+++ b/frontend/components/Header/AuthenticationStatus.tsx
@@ -66,9 +66,7 @@ function Unauthenticated() {
           minWidth: '5.25rem',
           visibility: status === 'unauthenticated' ? 'visible' : 'hidden',
         }}
-        onClick={() => signIn('keycloak', {
-          callbackUrl: window.location.href,
-        })}
+        onClick={() => signIn('keycloak')}
       >
         {t('sign in')}
       </Button>

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -10,8 +10,8 @@ import { SnackbarProvider } from '~/providers/SnackbarProvider';
 import { UserProvider } from '~/providers/UserProvider';
 import '~/styles/globals.css';
 import '~/styles/react-big-calendar.css';
-import LoginProvider from '../providers/LoginProvider';
-import ThemeProvider from '../providers/ThemeProvider';
+import LoginProvider from '~/providers/LoginProvider';
+import ThemeProvider from '~/providers/ThemeProvider';
 
 function MyApp({ Component, pageProps: { session, ...pageProps } }:
 AppProps & { Component: any, pageProps: any }) {
@@ -31,7 +31,7 @@ AppProps & { Component: any, pageProps: any }) {
         {pageProps.isNativeApp && <meta name="viewport" content="initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />}
       </Head>
       <NativeAppProvider isNativeApp={pageProps.isNativeApp}>
-        <LoginProvider session={session} apolloCache={pageProps.apolloCache}>
+        <LoginProvider session={session}>
           <ThemeProvider>
             <UserProvider>
               <ApiAccessProvider>

--- a/frontend/pages/mojt/boss.tsx
+++ b/frontend/pages/mojt/boss.tsx
@@ -88,7 +88,7 @@ export default function BossPage() {
           disabled={!message || !red || !green || !blue}
           onClick={() => {
             const data = {
-              message, red, green, blue, authToken: session.idToken,
+              message, red, green, blue, authToken: session.accessToken,
             };
             setStatus('');
             setError(false);

--- a/frontend/providers/LoginProvider.tsx
+++ b/frontend/providers/LoginProvider.tsx
@@ -1,17 +1,13 @@
 import React, { PropsWithChildren } from 'react';
-import { NormalizedCacheObject } from '@apollo/client';
 import { SessionProvider } from 'next-auth/react';
 import GraphQLProvider from '~/providers/GraphQLProvider';
 
-type LoginProviderProps = PropsWithChildren<{ session: any, apolloCache: NormalizedCacheObject }>;
+type LoginProviderProps = PropsWithChildren<{ session: any }>;
 
-function LoginProvider({ children, session, apolloCache }: LoginProviderProps) {
+function LoginProvider({ children, session }: LoginProviderProps) {
   return (
     <SessionProvider session={session}>
-      <GraphQLProvider
-        ssrApolloCache={apolloCache}
-        ssrToken={null}
-      >
+      <GraphQLProvider>
         {children}
       </GraphQLProvider>
     </SessionProvider>

--- a/frontend/types/next-auth.d.ts
+++ b/frontend/types/next-auth.d.ts
@@ -86,9 +86,12 @@ declare module 'next-auth/jwt' {
     email: string;
     sub: string;
     accessToken: string;
+    idToken: string;
     refreshToken: string;
-    accessTokenExpired: number;
-    refreshTokenExpired: number;
+    expiresAt: number;
+    given_name: string;
+    family_name: string;
+    preferred_username: string;
     user: User;
     error: string;
   }


### PR DESCRIPTION
Building upon the excellent documentation format in #1009, I saw it appropriate to do something similar for the rather convoluted mess of issues surrounding authentication.

- [x] Fix state mismatch errors
- [x] Stop showing onboarding for old users
- [ ] Make refresh tokens single use (Keycloak)
- [ ] Lock down redirect URL (Keycloak)

## Background
We use Keycloak for identity and access management. [Keycloak](https://www.keycloak.org/docs/latest/server_admin/#sso-protocols) provides [Single-Sign On (SSO)](https://auth0.com/docs/authenticate/single-sign-on) through [OpenID Connect (OIDC)](https://auth0.com/docs/authenticate/protocols/openid-connect-protocol), which is an authentication protocol that builds upon the [OAuth 2.0](https://auth0.com/docs/authenticate/protocols/oauth) framework.

Roughly speaking, OAuth 2.0 defines different authentication flows that allows clients to receive access tokens. These access tokens are subsequently used when fetching data from the backend. Access tokens are short-lived, so to avoid having to sign in over and over again refresh tokens are used. This is a long lived token that is used to fetch new access tokens when they expire. Anyway, the specific authentication flow we use is called [_Authorization Code_ (with PKCE)](https://auth0.com/docs/get-started/authentication-and-authorization-flow/authorization-code-flow-with-proof-key-for-code-exchange-pkce).

## How it works
1. User clicks sign in button and gets redirected to www.dsek.se/api/auth/signin.
2. NextAuth creates an Authorization Code Request URL (https://portal.dsek.se/realms/dsek/protocol/openid-connect/auth?params) and passes along multiple query params, including `client_id`, `scope`, and `redirect_uri`. Note especially that `redirect_uri` contains a `state` parameter which is a randomly generated value that's **unique to each request**.
4. Following successful authentication at https://portal.dsek.se the user gets redirected to the `redirect_uri`, which in our case is https://www.dsek.se/api/auth/callback/keycloak?params. `params` includes our access_token and the `state` parameter.
5. NextAuth.js receives the tokens and calls the [`jwt` callback](https://github.com/Dsek-LTH/member-page/blob/ecadfed268d87e1088a44f4bb3800961dc100850/frontend/pages/api/auth/%5B...nextauth%5D.ts#L95) with our new tokens as arguments. This callback is called both on sign in and every time we call the `useSession`-hook.
6. The [`session` callback](https://github.com/Dsek-LTH/member-page/blob/ecadfed268d87e1088a44f4bb3800961dc100850/frontend/pages/api/auth/%5B...nextauth%5D.ts#L117) is called with the token from the jwt callback as arg along with our session object. By modifying the session object we can forward properties to the client ([docs](https://next-auth.js.org/configuration/callbacks#session-callback)).

## Issues
### State mismatch
In the `jwt` callback we [check if the access token has expired](https://github.com/Dsek-LTH/member-page/blob/ecadfed268d87e1088a44f4bb3800961dc100850/frontend/pages/api/auth/%5B...nextauth%5D.ts#L111-L112). If it has, we [attempt to fetch a new one](https://github.com/Dsek-LTH/member-page/blob/ecadfed268d87e1088a44f4bb3800961dc100850/frontend/pages/api/auth/%5B...nextauth%5D.ts#L41) using our refresh token. And [if that also fails](https://github.com/Dsek-LTH/member-page/blob/ecadfed268d87e1088a44f4bb3800961dc100850/frontend/providers/UserProvider.tsx#L47), we conclude that our refresh token is no longer valid so we call `signIn` to force the user sign in again. Nothing wrong thus far, in fact it follows [the documentation](https://authjs.dev/guides/basics/refresh-token-rotation#client-side) to a tee.

However, from there on we start to deviate slightly. We call `signIn` in a useEffect with the dependency array `[data?.me, status, loading]` instead of simply `[session]` as in the docs. To some degree this is still speculation, but from testing I found that `status` will change to `"authenticated"` before the `session` object is mutated, which for our puposes means that `session.error` and `session.accessToken` will still be unchanged when `status` changes to `"authenticated"`. 

I think it's highly likely that once `status` gets changed to `"authenticated"`, the useEffect runs again, which in turn causes `signIn` to get called again since `session.error` has not yet been reset. And whenever `signIn` gets called it generates a new random state. Since this state value changes before the previous authentication flow has had time to finish it causes a state mismatch. Recall that the state gets passed as a param when redirected back from keycloak following successful authentication (step 4). This state must have the same value as the state originally sent in our Authorization Code Request URL (step 2).

See links below for more detailed information:
* [signIn](https://github.com/nextauthjs/next-auth/blob/6c07331cc53abe45c644308af6b6f2de29fdae2e/packages/next-auth/src/core/routes/signin.ts#L27) -> [auth code request url](https://github.com/nextauthjs/next-auth/blob/6c07331cc53abe45c644308af6b6f2de29fdae2e/packages/next-auth/src/core/lib/oauth/authorization-url.ts#L18) -> [create state](https://github.com/nextauthjs/next-auth/blob/6c07331cc53abe45c644308af6b6f2de29fdae2e/packages/next-auth/src/core/lib/oauth/state-handler.ts#L19) -> [generate state](https://github.com/panva/node-openid-client/blob/main/lib/helpers/generators.js#L9)
* [callback](https://github.com/nextauthjs/next-auth/blob/6c07331cc53abe45c644308af6b6f2de29fdae2e/packages/next-auth/src/core/routes/callback.ts#L40-L195) -> [callback error](https://github.com/nextauthjs/next-auth/blob/6c07331cc53abe45c644308af6b6f2de29fdae2e/packages/next-auth/src/core/lib/oauth/callback.ts#L66-L148)
* https://auth0.com/docs/secure/attack-protection/state-parameters
* https://authjs.dev/guides/basics/refresh-token-rotation

### Onboarding
In UserProvider we have a useEffect with the dependency array [data?.me, status, loading] that checks whether to onboard the user or not based on wheter or not the Me query returns a user. It is supposed to only perform this check after the user is successfully authenticated since the backend relies on the authorization token to check whether or not the user has been created. However, similar to the issues above a `state === "authenticated"` check is not sufficient to guarantee that the accessToken has been set. This causes us the check whether the user exists based on a fetch ran without the accessToken. If we fetch Me without setting the accessToken it will always return null since it has no idea yet who is fetching. The solution is to only fetch once the accessToken has been set in the apollo client.

### Refresh token rotation
For security reasons, refresh tokens should be single use. Using the keycloak option "Revoke refresh token" we get a new refresh token every time we use it to fetch a new access token. The old refresh token becomes invalid.

Note that the NextAuth.js docs uses the term "refresh token rotation" to refer to "access token rotation", as in the usage of refresh tokens to continually obtain new access tokens. That is not what is being referred to here.

See also:
https://www.keycloak.org/docs/latest/server_admin/#_timeouts (Revoke Refresh Token)
https://auth0.com/blog/refresh-tokens-what-are-they-and-when-to-use-them/#Refresh-Token-Rotation

### Redirect URLs
As stated in the OAuth 2.0 specification, it is especially important for non-authenticated clients (i.e our website/app) to employ strict redirect rules. We should only allow redirects to https://www.dsek.se/api/auth/callback/keycloak. This won't affect the frontend and will only require changes in Keycloak.

## Solutions
1. **State mismatch**: change useEffect dependencies to prevent signIn from being called during the signIn flow.
2. **Onboarding**: change useEffect dependencies to ensure current user identity is only called after access token is set.
3. **Refresh token rotation**: seems to already be implemented in frontend, keycloak config probably needs to change
4. **Redirect URLs**: change valid redirect URLs in Keycloak