### PR TITLE
:sparkles: Add positions pages

### DIFF
--- a/backend/services/core/graphql.schema.json
+++ b/backend/services/core/graphql.schema.json
@@ -11458,7 +11458,55 @@
             "deprecationReason": null
           },
           {
+            "name": "description",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "descriptionEn",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "email",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
             "name": "name",
+            "description": null,
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "defaultValue": null,
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "nameEn",
             "description": null,
             "type": {
               "kind": "SCALAR",

--- a/backend/services/core/src/datasources/Position.ts
+++ b/backend/services/core/src/datasources/Position.ts
@@ -102,10 +102,15 @@ export default class PositionAPI extends dbUtils.KnexDataSource {
   updatePosition(
     ctx: context.UserContext,
     id: string,
-    input: sql.UpdatePosition,
+    input: gql.UpdatePosition,
   ): Promise<gql.Maybe<gql.Position>> {
     return this.withAccess('core:position:update', ctx, async () => {
-      const res = (await this.knex<sql.Position>('positions').select('*').where({ id }).update(input)
+      const { nameEn, descriptionEn, ...inputRest } = input;
+      const res = (await this.knex<sql.Position>('positions').select('*').where({ id }).update({
+        name_en: nameEn,
+        description_en: descriptionEn,
+        ...inputRest,
+      })
         .returning('*'))[0];
 
       if (!res) { throw new UserInputError('id did not exist'); }

--- a/backend/services/core/src/schemas/core.graphql
+++ b/backend/services/core/src/schemas/core.graphql
@@ -253,7 +253,11 @@ input CreatePosition {
 
 input UpdatePosition {
   name: String
+  nameEn: String
+  description: String
+  descriptionEn: String
   committee_id: UUID
+  email: String
 }
 
 input CreateCommittee {

--- a/backend/services/core/src/types/graphql.ts
+++ b/backend/services/core/src/types/graphql.ts
@@ -1495,7 +1495,11 @@ export type UpdateMember = {
 
 export type UpdatePosition = {
   committee_id?: InputMaybe<Scalars['UUID']>;
+  description?: InputMaybe<Scalars['String']>;
+  descriptionEn?: InputMaybe<Scalars['String']>;
+  email?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
+  nameEn?: InputMaybe<Scalars['String']>;
 };
 
 export type UpdateTag = {

--- a/frontend/api/members.graphql
+++ b/frontend/api/members.graphql
@@ -12,6 +12,9 @@ query MeHeader {
         id
         name
         nameEn
+        committee {
+          name
+        }
       }
     }
   }
@@ -48,6 +51,9 @@ query MemberPage($id: UUID, $student_id: String) {
         name
         nameEn
         emailAliases
+        committee {
+          name
+        }
       }
     }
     activeMandates: mandates(onlyActive: true) {
@@ -56,6 +62,9 @@ query MemberPage($id: UUID, $student_id: String) {
         name
         nameEn
         emailAliases
+        committee {
+          name
+        }
       }
     }
   }

--- a/frontend/api/members.graphql
+++ b/frontend/api/members.graphql
@@ -12,9 +12,6 @@ query MeHeader {
         id
         name
         nameEn
-        committee {
-          name
-        }
       }
     }
   }

--- a/frontend/api/members.graphql
+++ b/frontend/api/members.graphql
@@ -50,7 +50,6 @@ query MemberPage($id: UUID, $student_id: String) {
         id
         name
         nameEn
-        emailAliases
         committee {
           name
         }
@@ -61,7 +60,7 @@ query MemberPage($id: UUID, $student_id: String) {
         id
         name
         nameEn
-        emailAliases
+        email
         committee {
           name
         }

--- a/frontend/api/positions.graphql
+++ b/frontend/api/positions.graphql
@@ -96,3 +96,43 @@ query AllPositions($committeeId: UUID) {
     }
   }
 }
+
+mutation UpdatePosition(
+  $id: String!,
+  $name: String,
+  $nameEn: String,
+  $description: String,
+  $descriptionEn: String,
+  $committee_id: UUID,
+  $email: String
+) {
+  position {
+    update(
+      id: $id,
+      input: {
+        name: $name,
+        nameEn: $nameEn,
+        description: $description,
+        descriptionEn: $descriptionEn,
+        committee_id: $committee_id,
+        email: $email
+      }
+    ) {
+      id
+      name
+      nameEn
+      description
+      descriptionEn
+      committee {
+        id
+        name
+        name_en
+        shortName
+      }
+      email
+      emailAliases
+      active
+      boardMember
+    }
+  }
+}

--- a/frontend/api/positions.graphql
+++ b/frontend/api/positions.graphql
@@ -18,6 +18,7 @@ query PositionsByCommittee($committeeId: UUID, $shortName: String, $year: Int) {
         name
         shortName
       }
+      email
       emailAliases
       activeMandates {
         id
@@ -40,6 +41,47 @@ query PositionsByCommittee($committeeId: UUID, $shortName: String, $year: Int) {
     }
     pageInfo {
       hasNextPage
+    }
+  }
+
+}
+
+query Position($id: String) {
+  positions(filter: { id: $id }, perPage: 1) {
+    positions {
+      id
+      name
+      nameEn
+      description
+      descriptionEn
+      committee {
+        id
+        name
+        shortName
+      }
+      email
+      emailAliases
+      active
+      boardMember
+    }
+  }
+  mandatePagination(
+    page: 0
+    perPage: 100000
+    filter: { position_id: $id }
+  ) {
+    mandates {
+      id
+      start_date
+      end_date
+      member {
+          id
+          picture_path
+          student_id
+          first_name
+          nickname
+          last_name
+      }
     }
   }
 }

--- a/frontend/api/positions.graphql
+++ b/frontend/api/positions.graphql
@@ -57,6 +57,7 @@ query Position($id: String) {
       committee {
         id
         name
+        name_en
         shortName
       }
       email

--- a/frontend/components/Committees/CommitteeIcon.tsx
+++ b/frontend/components/Committees/CommitteeIcon.tsx
@@ -13,6 +13,7 @@ import RocketLaunchIcon from '@mui/icons-material/RocketLaunch';
 import MilitaryTechIcon from '@mui/icons-material/MilitaryTech';
 import HowToVoteIcon from '@mui/icons-material/HowToVote';
 import StarsIcon from '@mui/icons-material/Stars';
+import { Diversity1, SportsBar } from '@mui/icons-material';
 
 export default function CommitteeIcon(props: any) {
   const { name } = props;
@@ -30,7 +31,7 @@ export default function CommitteeIcon(props: any) {
     case 'Informationsutskottet':
       return <NewspaperIcon {...props} />;
     case 'Sexmästeriet':
-      return <CelebrationIcon {...props} />;
+      return <SportsBar {...props} />;
     case 'Skattmästeriet':
       return <AttachMoneyIcon {...props} />;
     case 'Studierådet':
@@ -43,8 +44,10 @@ export default function CommitteeIcon(props: any) {
       return <MilitaryTechIcon {...props} />;
     case 'Valberedningen':
       return <HowToVoteIcon {...props} />;
-    /*     case 'Nollningsutskottet':
-      return; */
+    case 'Nollningsutskottet':
+      return <CelebrationIcon {...props} />;
+    case 'D-chip':
+      return <Diversity1 {...props} />;
     default:
       return <GroupIcon {...props} />;
   }

--- a/frontend/components/Committees/CommitteeIcon.tsx
+++ b/frontend/components/Committees/CommitteeIcon.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import LocalCafeIcon from '@mui/icons-material/LocalCafe';
 import BusinessIcon from '@mui/icons-material/Business';
 import GroupIcon from '@mui/icons-material/Group';
@@ -15,8 +15,8 @@ import HowToVoteIcon from '@mui/icons-material/HowToVote';
 import StarsIcon from '@mui/icons-material/Stars';
 import { Diversity1, SportsBar } from '@mui/icons-material';
 
-export default function CommitteeIcon(props: any) {
-  const { name } = props;
+export default function CommitteeIcon({ name, ...props }: { name: string } &
+ComponentProps<typeof StarsIcon>) {
   switch (name) {
     case 'Styrelsen':
       return <StarsIcon {...props} />;

--- a/frontend/components/Mandates/MandateList.tsx
+++ b/frontend/components/Mandates/MandateList.tsx
@@ -30,9 +30,9 @@ type PartialMandate = {
 };
 
 const getPositionIdFromName = (mandateList: GetMandatesByPeriodQuery['mandatePagination']['mandates'], positionName: string, isEnglish: boolean) => {
-  const translatedPositonName = (m: GetMandatesByPeriodQuery['mandatePagination']['mandates'][number]) =>
+  const translatedPositionName = (m: GetMandatesByPeriodQuery['mandatePagination']['mandates'][number]) =>
     (isEnglish && m.position.nameEn ? m.position.nameEn : m.position.name);
-  const posId = mandateList.find((m) => translatedPositonName(m) === positionName)?.position?.id;
+  const posId = mandateList.find((m) => translatedPositionName(m) === positionName)?.position?.id;
   return posId;
 };
 

--- a/frontend/components/Mandates/MandateList.tsx
+++ b/frontend/components/Mandates/MandateList.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from 'next-i18next';
 import React from 'react';
 import groupBy from '~/functions/groupBy';
 import {
+  GetMandatesByPeriodQuery,
   Maybe,
   Member,
   Position,
@@ -26,6 +27,13 @@ import routes from '~/routes';
 type PartialMandate = {
   position?: Partial<Position>;
   member?: Partial<Member>;
+};
+
+const getPositionIdFromName = (mandateList: GetMandatesByPeriodQuery['mandatePagination']['mandates'], positionName: string, isEnglish: boolean) => {
+  const translatedPositonName = (m: GetMandatesByPeriodQuery['mandatePagination']['mandates'][number]) =>
+    (isEnglish && m.position.nameEn ? m.position.nameEn : m.position.name);
+  const posId = mandateList.find((m) => translatedPositonName(m) === positionName)?.position?.id;
+  return posId;
 };
 
 export default function MandateList({ year }: { year: number }) {
@@ -68,11 +76,7 @@ export default function MandateList({ year }: { year: number }) {
         </TableHead>
         <TableBody>
           {positions.map((p, i) => {
-            const posId = mandateList.find((m) =>
-              (isEnglish && m.position.nameEn
-                ? m.position.nameEn
-                : m.position.name) === p)
-              ?.position?.id;
+            const posId = getPositionIdFromName(mandateList, p, isEnglish);
             return (mandatesByPosition.has(p) ? (
               <TableRow
                 className={i % 2 === 1 ? classes.rowOdd : classes.rowEven}

--- a/frontend/components/Mandates/MandateList.tsx
+++ b/frontend/components/Mandates/MandateList.tsx
@@ -20,6 +20,8 @@ import { hasAccess, useApiAccess } from '~/providers/ApiAccessProvider';
 import MandateSet from './MandateSet';
 import MandateSkeleton from './MandateSkeleton';
 import mandateStyles from './mandateStyles';
+import Link from '~/components/Link';
+import routes from '~/routes';
 
 type PartialMandate = {
   position?: Partial<Position>;
@@ -65,13 +67,25 @@ export default function MandateList({ year }: { year: number }) {
           </TableRow>
         </TableHead>
         <TableBody>
-          {positions.map((p, i) =>
-            (mandatesByPosition.has(p) ? (
+          {positions.map((p, i) => {
+            const posId = mandateList.find((m) =>
+              (isEnglish && m.position.nameEn
+                ? m.position.nameEn
+                : m.position.name) === p)
+              ?.position?.id;
+            return (mandatesByPosition.has(p) ? (
               <TableRow
                 className={i % 2 === 1 ? classes.rowOdd : classes.rowEven}
                 key={p}
               >
-                <TableCell>{p}</TableCell>
+                <TableCell>
+                  {posId ? (
+                    <Link href={routes.position(posId)}>
+                      {p}
+                    </Link>
+                  ) : p}
+
+                </TableCell>
                 <MandateSet members={mandatesByPosition.get(p)} />
               </TableRow>
             ) : (
@@ -79,7 +93,8 @@ export default function MandateList({ year }: { year: number }) {
                 <TableCell>{p}</TableCell>
                 <TableCell>{t('vakant')}</TableCell>
               </TableRow>
-            )))}
+            ));
+          })}
         </TableBody>
       </Table>
     </TableContainer>

--- a/frontend/components/Members/Member.tsx
+++ b/frontend/components/Members/Member.tsx
@@ -75,15 +75,30 @@ export default function Member({
             </Stack>
           </ListItem>
           {activePositions.length > 0 && (
-            <Box display="grid" gridTemplateColumns="auto 1fr" columnGap={2}>
+            <Box
+              display="grid"
+              sx={{
+                gridTemplateColumns: {
+                  xs: '1fr',
+                  md: 'auto 1fr',
+                },
+                maxWidth: '100%',
+                overflow: 'hidden',
+              }}
+              columnGap={2}
+            >
               {activePositions.map((position) => (
                 <>
-                  <Box gridColumn="span 1">
+                  <Box
+                    gridColumn="span 1"
+                  >
                     <Link href={`mailto:${position.email}`}>
                       {position.email}
                     </Link>
                   </Box>
-                  <Box gridColumn="span 1">
+                  <Box
+                    gridColumn="span 1"
+                  >
                     {selectTranslation(
                       i18n,
                       position.name,

--- a/frontend/components/Members/Member.tsx
+++ b/frontend/components/Members/Member.tsx
@@ -13,6 +13,8 @@ import { MemberPageQueryResult } from '~/generated/graphql';
 import { getClassYear, getFullName } from '~/functions/memberFunctions';
 import selectTranslation from '~/functions/selectTranslation';
 import Link from '~/components/Link';
+import routes from '~/routes';
+import CommitteeIcon from '~/components/Committees/CommitteeIcon';
 
 type MandateType = MemberPageQueryResult['data']['member']['mandates'][number];
 
@@ -93,15 +95,21 @@ export default function Member({
           )}
           {mandatesByYear.map((mandateCategory) => (
             <Stack key={`mandate-categegory${mandateCategory.year}`} style={{ marginTop: '1rem' }}>
-              <Typography variant="h5" color="primary">{mandateCategory.year}</Typography>
+              <Typography variant="h5">{mandateCategory.year}</Typography>
               {mandateCategory.mandates.map((mandate) => (
-                <Typography key={mandate.id} style={{ marginTop: '0.5rem', marginLeft: '0.5rem' }}>
-                  {selectTranslation(
-                    i18n,
-                    mandate.position.name,
-                    mandate.position.nameEn,
-                  )}
-                </Typography>
+                <Link key={mandate.id} href={routes.position(mandate.position.id)}>
+                  <Stack direction="row" alignItems="center">
+                    <CommitteeIcon name={mandate.position?.committee?.name} />
+                    <Typography style={{ marginTop: '0.5rem', marginLeft: '0.5rem' }}>
+                      {selectTranslation(
+                        i18n,
+                        mandate.position.name,
+                        mandate.position.nameEn,
+                      )}
+                    </Typography>
+                  </Stack>
+
+                </Link>
               ))}
             </Stack>
           ))}

--- a/frontend/components/Members/Member.tsx
+++ b/frontend/components/Members/Member.tsx
@@ -51,7 +51,9 @@ export default function Member({
     }, [] as StructuredMandates),
     [member.mandates],
   );
-  const emailAliases = member.activeMandates?.map((mandate) => ({ ...mandate.position }));
+  const activePositions = member.activeMandates
+    ?.map((mandate) => (mandate.position))
+    ?.filter((pos) => pos.email) ?? [];
   return (
     <Grid
       container
@@ -72,25 +74,24 @@ export default function Member({
               <ListItemText primary={getClassYear(member)} />
             </Stack>
           </ListItem>
-          {emailAliases.length > 0 && (
+          {activePositions.length > 0 && (
             <Box display="grid" gridTemplateColumns="auto 1fr" columnGap={2}>
-              {emailAliases.map((emailAlias) => (
-                emailAlias.emailAliases.map((alias) => (
-                  <>
-                    <Box gridColumn="span 1">
-                      <Link href={`mailto:${alias}`}>
-                        {alias}
-                      </Link>
-                    </Box>
-                    <Box gridColumn="span 1">
-                      {selectTranslation(
-                        i18n,
-                        emailAlias.name,
-                        emailAlias.nameEn,
-                      )}
-                    </Box>
-                  </>
-                ))))}
+              {activePositions.map((position) => (
+                <>
+                  <Box gridColumn="span 1">
+                    <Link href={`mailto:${position.email}`}>
+                      {position.email}
+                    </Link>
+                  </Box>
+                  <Box gridColumn="span 1">
+                    {selectTranslation(
+                      i18n,
+                      position.name,
+                      position.nameEn,
+                    )}
+                  </Box>
+                </>
+              ))}
             </Box>
           )}
           {mandatesByYear.map((mandateCategory) => (

--- a/frontend/components/Positions/Position.tsx
+++ b/frontend/components/Positions/Position.tsx
@@ -10,6 +10,7 @@ import selectTranslation from '~/functions/selectTranslation';
 import Mandate from './Mandate';
 import { hasAccess, useApiAccess } from '~/providers/ApiAccessProvider';
 import Link from '~/components/Link';
+import routes from '~/routes';
 
 const Container = styled(Paper)`
   display: flex;
@@ -43,9 +44,11 @@ function Position({
         maxWidth: { xs: '95%', sm: 450, xl: 500 },
       }}
     >
-      <PositionTitle variant="h4" sx={{ mb: position.emailAliases?.length > 0 ? 0 : 1 }}>
-        {selectTranslation(i18n, position.name, position.nameEn)}
-      </PositionTitle>
+      <Link href={routes.position(position.id)}>
+        <PositionTitle variant="h4" sx={{ mb: position.emailAliases?.length > 0 ? 0 : 1 }}>
+          {selectTranslation(i18n, position.name, position.nameEn)}
+        </PositionTitle>
+      </Link>
       {position.emailAliases?.length > 0 && (
         <Stack direction="row" flexWrap="wrap" columnGap={2} sx={{ fontSize: 12, mb: 1 }}>
           {position.emailAliases.map((alias) => (

--- a/frontend/components/Positions/Position.tsx
+++ b/frontend/components/Positions/Position.tsx
@@ -49,13 +49,11 @@ function Position({
           {selectTranslation(i18n, position.name, position.nameEn)}
         </PositionTitle>
       </Link>
-      {position.emailAliases?.length > 0 && (
+      {position.email && (
         <Stack direction="row" flexWrap="wrap" columnGap={2} sx={{ fontSize: 12, mb: 1 }}>
-          {position.emailAliases.map((alias) => (
-            <Link key={alias} href={`mailto:${alias}`}>
-              {alias}
-            </Link>
-          ))}
+          <Link href={`mailto:${position.email}`}>
+            {position.email}
+          </Link>
         </Stack>
       )}
       {position.description && (

--- a/frontend/generated/graphql.tsx
+++ b/frontend/generated/graphql.tsx
@@ -2377,7 +2377,7 @@ export type PositionQueryVariables = Exact<{
 }>;
 
 
-export type PositionQuery = { __typename?: 'Query', positions?: { __typename?: 'PositionPagination', positions: Array<{ __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, description?: string | null, descriptionEn?: string | null, email?: string | null, emailAliases?: Array<string> | null, active?: boolean | null, boardMember?: boolean | null, committee?: { __typename?: 'Committee', id: any, name?: string | null, shortName: string } | null } | null> } | null, mandatePagination?: { __typename?: 'MandatePagination', mandates: Array<{ __typename?: 'FastMandate', id: any, start_date: any, end_date: any, member?: { __typename?: 'Member', id: any, picture_path?: string | null, student_id?: string | null, first_name?: string | null, nickname?: string | null, last_name?: string | null } | null } | null> } | null };
+export type PositionQuery = { __typename?: 'Query', positions?: { __typename?: 'PositionPagination', positions: Array<{ __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, description?: string | null, descriptionEn?: string | null, email?: string | null, emailAliases?: Array<string> | null, active?: boolean | null, boardMember?: boolean | null, committee?: { __typename?: 'Committee', id: any, name?: string | null, name_en?: string | null, shortName: string } | null } | null> } | null, mandatePagination?: { __typename?: 'MandatePagination', mandates: Array<{ __typename?: 'FastMandate', id: any, start_date: any, end_date: any, member?: { __typename?: 'Member', id: any, picture_path?: string | null, student_id?: string | null, first_name?: string | null, nickname?: string | null, last_name?: string | null } | null } | null> } | null };
 
 export type AllPositionsQueryVariables = Exact<{
   committeeId?: InputMaybe<Scalars['UUID']>;
@@ -6983,6 +6983,7 @@ export const PositionDocument = gql`
       committee {
         id
         name
+        name_en
         shortName
       }
       email

--- a/frontend/generated/graphql.tsx
+++ b/frontend/generated/graphql.tsx
@@ -2149,7 +2149,7 @@ export type MemberPageQueryVariables = Exact<{
 }>;
 
 
-export type MemberPageQuery = { __typename?: 'Query', member?: { __typename?: 'Member', id: any, student_id?: string | null, first_name?: string | null, nickname?: string | null, last_name?: string | null, class_programme?: string | null, class_year?: number | null, picture_path?: string | null, mandates?: Array<{ __typename?: 'Mandate', id: any, start_date: any, end_date: any, position?: { __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, emailAliases?: Array<string> | null, committee?: { __typename?: 'Committee', name?: string | null } | null } | null }> | null, activeMandates?: Array<{ __typename?: 'Mandate', position?: { __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, emailAliases?: Array<string> | null, committee?: { __typename?: 'Committee', name?: string | null } | null } | null }> | null } | null };
+export type MemberPageQuery = { __typename?: 'Query', member?: { __typename?: 'Member', id: any, student_id?: string | null, first_name?: string | null, nickname?: string | null, last_name?: string | null, class_programme?: string | null, class_year?: number | null, picture_path?: string | null, mandates?: Array<{ __typename?: 'Mandate', id: any, start_date: any, end_date: any, position?: { __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, committee?: { __typename?: 'Committee', name?: string | null } | null } | null }> | null, activeMandates?: Array<{ __typename?: 'Mandate', position?: { __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, email?: string | null, committee?: { __typename?: 'Committee', name?: string | null } | null } | null }> | null } | null };
 
 export type CreateMemberMutationVariables = Exact<{
   firstName: Scalars['String'];
@@ -5562,7 +5562,6 @@ export const MemberPageDocument = gql`
         id
         name
         nameEn
-        emailAliases
         committee {
           name
         }
@@ -5573,7 +5572,7 @@ export const MemberPageDocument = gql`
         id
         name
         nameEn
-        emailAliases
+        email
         committee {
           name
         }

--- a/frontend/generated/graphql.tsx
+++ b/frontend/generated/graphql.tsx
@@ -2132,7 +2132,7 @@ export type CreateMarkdownMutation = { __typename?: 'Mutation', markdown?: { __t
 export type MeHeaderQueryVariables = Exact<{ [key: string]: never; }>;
 
 
-export type MeHeaderQuery = { __typename?: 'Query', me?: { __typename?: 'Member', id: any, student_id?: string | null, first_name?: string | null, nickname?: string | null, last_name?: string | null, picture_path?: string | null, mandates?: Array<{ __typename?: 'Mandate', id: any, position?: { __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null } | null }> | null } | null };
+export type MeHeaderQuery = { __typename?: 'Query', me?: { __typename?: 'Member', id: any, student_id?: string | null, first_name?: string | null, nickname?: string | null, last_name?: string | null, picture_path?: string | null, mandates?: Array<{ __typename?: 'Mandate', id: any, position?: { __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, committee?: { __typename?: 'Committee', name?: string | null } | null } | null }> | null } | null };
 
 export type GetMembersQueryVariables = Exact<{ [key: string]: never; }>;
 
@@ -2145,7 +2145,7 @@ export type MemberPageQueryVariables = Exact<{
 }>;
 
 
-export type MemberPageQuery = { __typename?: 'Query', member?: { __typename?: 'Member', id: any, student_id?: string | null, first_name?: string | null, nickname?: string | null, last_name?: string | null, class_programme?: string | null, class_year?: number | null, picture_path?: string | null, mandates?: Array<{ __typename?: 'Mandate', id: any, start_date: any, end_date: any, position?: { __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, emailAliases?: Array<string> | null } | null }> | null, activeMandates?: Array<{ __typename?: 'Mandate', position?: { __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, emailAliases?: Array<string> | null } | null }> | null } | null };
+export type MemberPageQuery = { __typename?: 'Query', member?: { __typename?: 'Member', id: any, student_id?: string | null, first_name?: string | null, nickname?: string | null, last_name?: string | null, class_programme?: string | null, class_year?: number | null, picture_path?: string | null, mandates?: Array<{ __typename?: 'Mandate', id: any, start_date: any, end_date: any, position?: { __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, emailAliases?: Array<string> | null, committee?: { __typename?: 'Committee', name?: string | null } | null } | null }> | null, activeMandates?: Array<{ __typename?: 'Mandate', position?: { __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, emailAliases?: Array<string> | null, committee?: { __typename?: 'Committee', name?: string | null } | null } | null }> | null } | null };
 
 export type CreateMemberMutationVariables = Exact<{
   firstName: Scalars['String'];
@@ -2370,7 +2370,14 @@ export type PositionsByCommitteeQueryVariables = Exact<{
 }>;
 
 
-export type PositionsByCommitteeQuery = { __typename?: 'Query', positions?: { __typename?: 'PositionPagination', positions: Array<{ __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, description?: string | null, descriptionEn?: string | null, emailAliases?: Array<string> | null, committee?: { __typename?: 'Committee', id: any, name?: string | null, shortName: string } | null, activeMandates?: Array<{ __typename?: 'Mandate', id: any, start_date: any, end_date: any, position?: { __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null } | null, member?: { __typename?: 'Member', id: any, picture_path?: string | null, student_id?: string | null, first_name?: string | null, last_name?: string | null } | null } | null> | null } | null>, pageInfo: { __typename?: 'PaginationInfo', hasNextPage: boolean } } | null };
+export type PositionsByCommitteeQuery = { __typename?: 'Query', positions?: { __typename?: 'PositionPagination', positions: Array<{ __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, description?: string | null, descriptionEn?: string | null, email?: string | null, emailAliases?: Array<string> | null, committee?: { __typename?: 'Committee', id: any, name?: string | null, shortName: string } | null, activeMandates?: Array<{ __typename?: 'Mandate', id: any, start_date: any, end_date: any, position?: { __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null } | null, member?: { __typename?: 'Member', id: any, picture_path?: string | null, student_id?: string | null, first_name?: string | null, last_name?: string | null } | null } | null> | null } | null>, pageInfo: { __typename?: 'PaginationInfo', hasNextPage: boolean } } | null };
+
+export type PositionQueryVariables = Exact<{
+  id?: InputMaybe<Scalars['String']>;
+}>;
+
+
+export type PositionQuery = { __typename?: 'Query', positions?: { __typename?: 'PositionPagination', positions: Array<{ __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, description?: string | null, descriptionEn?: string | null, email?: string | null, emailAliases?: Array<string> | null, active?: boolean | null, boardMember?: boolean | null, committee?: { __typename?: 'Committee', id: any, name?: string | null, shortName: string } | null } | null> } | null, mandatePagination?: { __typename?: 'MandatePagination', mandates: Array<{ __typename?: 'FastMandate', id: any, start_date: any, end_date: any, member?: { __typename?: 'Member', id: any, picture_path?: string | null, student_id?: string | null, first_name?: string | null, nickname?: string | null, last_name?: string | null } | null } | null> } | null };
 
 export type AllPositionsQueryVariables = Exact<{
   committeeId?: InputMaybe<Scalars['UUID']>;
@@ -5444,6 +5451,9 @@ export const MeHeaderDocument = gql`
         id
         name
         nameEn
+        committee {
+          name
+        }
       }
     }
   }
@@ -5536,6 +5546,9 @@ export const MemberPageDocument = gql`
         name
         nameEn
         emailAliases
+        committee {
+          name
+        }
       }
     }
     activeMandates: mandates(onlyActive: true) {
@@ -5544,6 +5557,9 @@ export const MemberPageDocument = gql`
         name
         nameEn
         emailAliases
+        committee {
+          name
+        }
       }
     }
   }
@@ -6898,6 +6914,7 @@ export const PositionsByCommitteeDocument = gql`
         name
         shortName
       }
+      email
       emailAliases
       activeMandates {
         id
@@ -6954,6 +6971,71 @@ export function usePositionsByCommitteeLazyQuery(baseOptions?: Apollo.LazyQueryH
 export type PositionsByCommitteeQueryHookResult = ReturnType<typeof usePositionsByCommitteeQuery>;
 export type PositionsByCommitteeLazyQueryHookResult = ReturnType<typeof usePositionsByCommitteeLazyQuery>;
 export type PositionsByCommitteeQueryResult = Apollo.QueryResult<PositionsByCommitteeQuery, PositionsByCommitteeQueryVariables>;
+export const PositionDocument = gql`
+    query Position($id: String) {
+  positions(filter: {id: $id}, perPage: 1) {
+    positions {
+      id
+      name
+      nameEn
+      description
+      descriptionEn
+      committee {
+        id
+        name
+        shortName
+      }
+      email
+      emailAliases
+      active
+      boardMember
+    }
+  }
+  mandatePagination(page: 0, perPage: 100000, filter: {position_id: $id}) {
+    mandates {
+      id
+      start_date
+      end_date
+      member {
+        id
+        picture_path
+        student_id
+        first_name
+        nickname
+        last_name
+      }
+    }
+  }
+}
+    `;
+
+/**
+ * __usePositionQuery__
+ *
+ * To run a query within a React component, call `usePositionQuery` and pass it any options that fit your needs.
+ * When your component renders, `usePositionQuery` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the query, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = usePositionQuery({
+ *   variables: {
+ *      id: // value for 'id'
+ *   },
+ * });
+ */
+export function usePositionQuery(baseOptions?: Apollo.QueryHookOptions<PositionQuery, PositionQueryVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useQuery<PositionQuery, PositionQueryVariables>(PositionDocument, options);
+      }
+export function usePositionLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<PositionQuery, PositionQueryVariables>) {
+          const options = {...defaultOptions, ...baseOptions}
+          return Apollo.useLazyQuery<PositionQuery, PositionQueryVariables>(PositionDocument, options);
+        }
+export type PositionQueryHookResult = ReturnType<typeof usePositionQuery>;
+export type PositionLazyQueryHookResult = ReturnType<typeof usePositionLazyQuery>;
+export type PositionQueryResult = Apollo.QueryResult<PositionQuery, PositionQueryVariables>;
 export const AllPositionsDocument = gql`
     query AllPositions($committeeId: UUID) {
   positions(filter: {committee_id: $committeeId}, perPage: 1000) {

--- a/frontend/generated/graphql.tsx
+++ b/frontend/generated/graphql.tsx
@@ -1502,7 +1502,11 @@ export type UpdateMember = {
 
 export type UpdatePosition = {
   committee_id?: InputMaybe<Scalars['UUID']>;
+  description?: InputMaybe<Scalars['String']>;
+  descriptionEn?: InputMaybe<Scalars['String']>;
+  email?: InputMaybe<Scalars['String']>;
   name?: InputMaybe<Scalars['String']>;
+  nameEn?: InputMaybe<Scalars['String']>;
 };
 
 export type UpdateTag = {
@@ -2385,6 +2389,19 @@ export type AllPositionsQueryVariables = Exact<{
 
 
 export type AllPositionsQuery = { __typename?: 'Query', positions?: { __typename?: 'PositionPagination', positions: Array<{ __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null } | null> } | null };
+
+export type UpdatePositionMutationVariables = Exact<{
+  id: Scalars['String'];
+  name?: InputMaybe<Scalars['String']>;
+  nameEn?: InputMaybe<Scalars['String']>;
+  description?: InputMaybe<Scalars['String']>;
+  descriptionEn?: InputMaybe<Scalars['String']>;
+  committee_id?: InputMaybe<Scalars['UUID']>;
+  email?: InputMaybe<Scalars['String']>;
+}>;
+
+
+export type UpdatePositionMutation = { __typename?: 'Mutation', position?: { __typename?: 'PositionMutations', update?: { __typename?: 'Position', id: string, name?: string | null, nameEn?: string | null, description?: string | null, descriptionEn?: string | null, email?: string | null, emailAliases?: Array<string> | null, active?: boolean | null, boardMember?: boolean | null, committee?: { __typename?: 'Committee', id: any, name?: string | null, name_en?: string | null, shortName: string } | null } | null } | null };
 
 export type ProductsQueryVariables = Exact<{
   categoryId?: InputMaybe<Scalars['UUID']>;
@@ -7076,6 +7093,64 @@ export function useAllPositionsLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
 export type AllPositionsQueryHookResult = ReturnType<typeof useAllPositionsQuery>;
 export type AllPositionsLazyQueryHookResult = ReturnType<typeof useAllPositionsLazyQuery>;
 export type AllPositionsQueryResult = Apollo.QueryResult<AllPositionsQuery, AllPositionsQueryVariables>;
+export const UpdatePositionDocument = gql`
+    mutation UpdatePosition($id: String!, $name: String, $nameEn: String, $description: String, $descriptionEn: String, $committee_id: UUID, $email: String) {
+  position {
+    update(
+      id: $id
+      input: {name: $name, nameEn: $nameEn, description: $description, descriptionEn: $descriptionEn, committee_id: $committee_id, email: $email}
+    ) {
+      id
+      name
+      nameEn
+      description
+      descriptionEn
+      committee {
+        id
+        name
+        name_en
+        shortName
+      }
+      email
+      emailAliases
+      active
+      boardMember
+    }
+  }
+}
+    `;
+export type UpdatePositionMutationFn = Apollo.MutationFunction<UpdatePositionMutation, UpdatePositionMutationVariables>;
+
+/**
+ * __useUpdatePositionMutation__
+ *
+ * To run a mutation, you first call `useUpdatePositionMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useUpdatePositionMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [updatePositionMutation, { data, loading, error }] = useUpdatePositionMutation({
+ *   variables: {
+ *      id: // value for 'id'
+ *      name: // value for 'name'
+ *      nameEn: // value for 'nameEn'
+ *      description: // value for 'description'
+ *      descriptionEn: // value for 'descriptionEn'
+ *      committee_id: // value for 'committee_id'
+ *      email: // value for 'email'
+ *   },
+ * });
+ */
+export function useUpdatePositionMutation(baseOptions?: Apollo.MutationHookOptions<UpdatePositionMutation, UpdatePositionMutationVariables>) {
+        const options = {...defaultOptions, ...baseOptions}
+        return Apollo.useMutation<UpdatePositionMutation, UpdatePositionMutationVariables>(UpdatePositionDocument, options);
+      }
+export type UpdatePositionMutationHookResult = ReturnType<typeof useUpdatePositionMutation>;
+export type UpdatePositionMutationResult = Apollo.MutationResult<UpdatePositionMutation>;
+export type UpdatePositionMutationOptions = Apollo.BaseMutationOptions<UpdatePositionMutation, UpdatePositionMutationVariables>;
 export const ProductsDocument = gql`
     query Products($categoryId: UUID) {
   products(categoryId: $categoryId) {

--- a/frontend/hooks/useCommittees.ts
+++ b/frontend/hooks/useCommittees.ts
@@ -5,7 +5,7 @@ export const styrelsen: GetCommitteesQuery['committees']['committees'][number] =
   id: '1337',
   shortName: 'styr',
   name: 'Styrelsen',
-  name_en: 'Board',
+  name_en: 'The Board',
 };
 
 const useCommittees = () => {

--- a/frontend/pages/positions/[id].tsx
+++ b/frontend/pages/positions/[id].tsx
@@ -1,0 +1,136 @@
+import
+{
+  Avatar,
+  Link, Paper, Stack, Typography, styled,
+} from '@mui/material';
+import { useRouter } from 'next/router';
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import Mandate from '~/components/Positions/Mandate';
+import genGetProps from '~/functions/genGetServerSideProps';
+import { getFullName } from '~/functions/memberFunctions';
+import selectTranslation from '~/functions/selectTranslation';
+import { PositionQueryResult, usePositionQuery } from '~/generated/graphql';
+import { useApiAccess } from '~/providers/ApiAccessProvider';
+import routes from '~/routes';
+
+const Container = styled(Paper)`
+  display: flex;
+  flex-direction: column;
+  padding: 1rem;
+  margin: 1rem;
+`;
+
+const PositionTitle = styled(Typography)`
+  word-break: break-all;
+  hyphens: auto;
+`;
+
+const PositionDescription = styled(Typography)`
+  margin-bottom: 1rem;
+`;
+type MandateType = PositionQueryResult['data']['mandatePagination']['mandates'][number];
+type StructuredMandates = {
+  year: string;
+  mandates: MandateType[];
+}[];
+function PositionCard({ position, mandates }) {
+  const { t, i18n } = useTranslation(['common', 'position']);
+  const apiContext = useApiAccess();
+
+  // Format mandates as an ordered array
+  const mandatesByYear: StructuredMandates = useMemo(
+    () => mandates.reduce((acc: StructuredMandates, mandate: MandateType) => {
+      const startYear = new Date(mandate.start_date).getFullYear();
+      const endYear = new Date(mandate.end_date).getFullYear();
+      const year: string = startYear === endYear ? startYear.toString() : `${startYear}-${endYear}`;
+      const existing = acc.find((m) => m.year === year);
+      if (existing) {
+        existing.mandates.push(mandate);
+      } else {
+        // add in correct position in ascending order
+        const index = acc.findIndex((m) => m.year < year);
+        if (index === -1) {
+          acc.push({ year, mandates: [mandate] });
+        } else {
+          acc.splice(index, 0, { year, mandates: [mandate] });
+        }
+      }
+      return acc;
+    }, [] as StructuredMandates),
+    [mandates],
+  );
+
+  return (
+    <Container>
+      <PositionTitle variant="h4" sx={{ mb: 2 }}>
+        {selectTranslation(i18n, position.name, position.nameEn)}
+        <br />
+        {position.email && (
+        <Link fontSize="0.8em" href={`mailto:${position.email}`}>
+          {position.email}
+        </Link>
+        )}
+      </PositionTitle>
+      {position.emailAliases?.length > 0 && (
+      <>
+        <Typography fontSize="0.8rem">
+          {t('position:otherEmails')}
+        </Typography>
+        <Stack direction="row" flexWrap="wrap" columnGap={2} sx={{ fontSize: 12, mb: 1 }}>
+          {position.emailAliases.map((alias) => (
+            <Link key={alias} href={`mailto:${alias}`}>
+              {alias}
+            </Link>
+          ))}
+        </Stack>
+      </>
+      )}
+
+      {position.description && (
+      <PositionDescription>
+        {selectTranslation(i18n, position.description, position.descriptionEn)}
+      </PositionDescription>
+      )}
+      <Stack gap={1}>
+        {mandatesByYear.map((mandateAndYear) => (
+          <Stack key={`mandate-categegory${mandateAndYear.year}`} style={{ marginTop: '1rem' }} gap={1}>
+            <Typography variant="h5">{mandateAndYear.year}</Typography>
+            {mandateAndYear.mandates.map(({ id, member }) => (
+              <Link key={id} href={routes.member(member.id)}>
+                <Stack direction="row" alignItems="center">
+                  <Avatar
+                    src={member.picture_path}
+                    style={{
+                      width: 50,
+                      height: 50,
+                    }}
+                  />
+                  <Typography style={{ marginLeft: '1rem' }}>
+                    {getFullName(member)}
+                  </Typography>
+                </Stack>
+
+              </Link>
+            ))}
+          </Stack>
+        ))}
+      </Stack>
+    </Container>
+  );
+}
+
+export default function PositionPage() {
+  const router = useRouter();
+  const { id } = router.query;
+  const { data, loading } = usePositionQuery({ variables: { id: id.toString() } });
+  if (loading) return null;
+  const position = data?.positions?.positions[0];
+  if (!data || !position) return <div>Position not found</div>;
+  const { mandates } = data.mandatePagination;
+  return (
+    <PositionCard position={position} mandates={mandates} />
+  );
+}
+
+export const getServerSideProps = genGetProps(['position']);

--- a/frontend/pages/positions/[id].tsx
+++ b/frontend/pages/positions/[id].tsx
@@ -6,12 +6,11 @@ import
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import Mandate from '~/components/Positions/Mandate';
+import CommitteeIcon from '~/components/Committees/CommitteeIcon';
 import genGetProps from '~/functions/genGetServerSideProps';
 import { getFullName } from '~/functions/memberFunctions';
 import selectTranslation from '~/functions/selectTranslation';
 import { PositionQueryResult, usePositionQuery } from '~/generated/graphql';
-import { useApiAccess } from '~/providers/ApiAccessProvider';
 import routes from '~/routes';
 
 const Container = styled(Paper)`
@@ -34,9 +33,15 @@ type StructuredMandates = {
   year: string;
   mandates: MandateType[];
 }[];
-function PositionCard({ position, mandates }) {
+function PositionCard({
+  position,
+  mandates,
+}:
+{
+  position: PositionQueryResult['data']['positions']['positions'][number];
+  mandates: MandateType[]
+}) {
   const { t, i18n } = useTranslation(['common', 'position']);
-  const apiContext = useApiAccess();
 
   // Format mandates as an ordered array
   const mandatesByYear: StructuredMandates = useMemo(
@@ -61,24 +66,39 @@ function PositionCard({ position, mandates }) {
     [mandates],
   );
 
+  const emailAliases = position.emailAliases?.filter((alias) => alias !== position.email);
+
   return (
     <Container>
-      <PositionTitle variant="h4" sx={{ mb: 2 }}>
-        {selectTranslation(i18n, position.name, position.nameEn)}
-        <br />
-        {position.email && (
-        <Link fontSize="0.8em" href={`mailto:${position.email}`}>
-          {position.email}
-        </Link>
-        )}
-      </PositionTitle>
-      {position.emailAliases?.length > 0 && (
+      <Stack
+        direction="row"
+        gap={1}
+        alignItems="center"
+      >
+        <PositionTitle variant="h4">
+          <Link
+            href={routes.committeePage(position.committee.shortName)}
+            sx={{ mr: 2 }}
+          >
+            <CommitteeIcon name={position.committee.name} />
+          </Link>
+          {selectTranslation(i18n, position.name, position.nameEn)}
+        </PositionTitle>
+      </Stack>
+      {position.email && (
+        <PositionTitle variant="h4" sx={{ mb: 1 }}>
+          <Link fontSize="0.8em" href={`mailto:${position.email}`}>
+            {position.email}
+          </Link>
+        </PositionTitle>
+      )}
+      {emailAliases?.length > 0 && (
       <>
         <Typography fontSize="0.8rem">
           {t('position:otherEmails')}
         </Typography>
         <Stack direction="row" flexWrap="wrap" columnGap={2} sx={{ fontSize: 12, mb: 1 }}>
-          {position.emailAliases.map((alias) => (
+          {emailAliases.map((alias) => (
             <Link key={alias} href={`mailto:${alias}`}>
               {alias}
             </Link>

--- a/frontend/pages/positions/[id]/edit.tsx
+++ b/frontend/pages/positions/[id]/edit.tsx
@@ -1,0 +1,120 @@
+import
+{
+  Button,
+  CircularProgress,
+  MenuItem, Paper, Select, Stack, TextField, Typography,
+} from '@mui/material';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import genGetProps from '~/functions/genGetServerSideProps';
+import { usePositionQuery, useUpdatePositionMutation } from '~/generated/graphql';
+import useCommittees from '~/hooks/useCommittees';
+import { useApiAccess } from '~/providers/ApiAccessProvider';
+
+export default function EditPosition() {
+  const router = useRouter();
+  const { id } = router.query;
+  const { data, loading } = usePositionQuery({ variables: { id: id.toString() } });
+  const { committees } = useCommittees();
+
+  const position = data?.positions?.positions[0];
+  const [name, setName] = useState(position?.name ?? '');
+  const [nameEn, setNameEn] = useState(position?.nameEn ?? '');
+  const [description, setDescription] = useState(position?.description ?? '');
+  const [descriptionEn, setDescriptionEn] = useState(position?.descriptionEn ?? '');
+  const [email, setEmail] = useState(position?.email ?? '');
+  const [committee, setCommittee] = useState(position?.committee?.id ?? '');
+
+  const [updatePosition] = useUpdatePositionMutation();
+  const [isLoading, setIsLoading] = useState(false);
+
+  const save = async () => {
+    setIsLoading(true);
+    await updatePosition({
+      variables: {
+        id: position.id,
+        name,
+        nameEn,
+        description,
+        descriptionEn,
+        email,
+        committee_id: committee,
+      },
+    });
+    setIsLoading(false);
+  };
+
+  const { hasAccess } = useApiAccess();
+
+  useEffect(() => {
+    if (position) {
+      setName(position.name);
+      setNameEn(position.nameEn);
+      setDescription(position.description);
+      setDescriptionEn(position.descriptionEn);
+      setEmail(position.email);
+      setCommittee(position.committee.id);
+    }
+  }, [position]);
+  if (loading) return null;
+  if (!data || !position) return <div>Position not found</div>;
+  if (!hasAccess('core:position:update')) return <div>Access denied</div>;
+  return (
+    <Paper sx={{ p: 4 }}>
+      <Stack gap={2}>
+        <Typography variant="h4" mb={2}>
+          Redigera
+          {' '}
+          {position.name}
+        </Typography>
+        <TextField
+          label="Name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <TextField
+          label="Name (En)"
+          value={nameEn}
+          onChange={(e) => setNameEn(e.target.value)}
+        />
+        <TextField
+          multiline
+          label="Description"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+        <TextField
+          multiline
+          label="Description (En)"
+          value={descriptionEn}
+          onChange={(e) => setDescriptionEn(e.target.value)}
+        />
+        <TextField
+          label="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        {/* Comittee selector */}
+        <Select
+          label="Committee"
+          value={committee}
+          onChange={(e) => setCommittee(e.target.value)}
+        >
+          {committees.map((com) => (
+            <MenuItem key={com.id} value={com.id}>
+              {com.name}
+            </MenuItem>
+          ))}
+        </Select>
+        <Button
+          variant="contained"
+          onClick={save}
+        >
+          {isLoading ? <CircularProgress size={24} /> : 'Spara'}
+        </Button>
+      </Stack>
+    </Paper>
+  );
+}
+
+export const getServerSideProps = genGetProps(['position']);

--- a/frontend/pages/positions/[id]/index.tsx
+++ b/frontend/pages/positions/[id]/index.tsx
@@ -1,6 +1,7 @@
 import
 {
   Avatar,
+  Button,
   Link, Paper, Stack, Typography, styled,
 } from '@mui/material';
 import { useRouter } from 'next/router';
@@ -11,6 +12,7 @@ import genGetProps from '~/functions/genGetServerSideProps';
 import { getFullName } from '~/functions/memberFunctions';
 import selectTranslation from '~/functions/selectTranslation';
 import { PositionQueryResult, usePositionQuery } from '~/generated/graphql';
+import { useApiAccess } from '~/providers/ApiAccessProvider';
 import routes from '~/routes';
 
 const Container = styled(Paper)`
@@ -42,6 +44,7 @@ function PositionCard({
   mandates: MandateType[]
 }) {
   const { t, i18n } = useTranslation(['common', 'position']);
+  const { hasAccess } = useApiAccess();
 
   // Format mandates as an ordered array
   const mandatesByYear: StructuredMandates = useMemo(
@@ -70,20 +73,27 @@ function PositionCard({
 
   return (
     <Container>
-      <Stack
-        direction="row"
-        gap={1}
-        alignItems="center"
-      >
-        <PositionTitle variant="h4">
-          <Link
-            href={routes.committeePage(position.committee.shortName)}
-            sx={{ mr: 2 }}
-          >
-            <CommitteeIcon name={position.committee.name} />
+      <Stack direction="row" justifyContent="space-between">
+        <Stack
+          direction="row"
+          gap={1}
+          alignItems="center"
+        >
+          <PositionTitle variant="h4">
+            <Link
+              href={routes.committeePage(position.committee.shortName)}
+              sx={{ mr: 2 }}
+            >
+              <CommitteeIcon name={position.committee.name} />
+            </Link>
+            {selectTranslation(i18n, position.name, position.nameEn)}
+          </PositionTitle>
+        </Stack>
+        {hasAccess('core:position:update') && (
+          <Link href={routes.editPosition(position.id)} component={Button}>
+            Edit
           </Link>
-          {selectTranslation(i18n, position.name, position.nameEn)}
-        </PositionTitle>
+        )}
       </Stack>
       {position.email && (
         <PositionTitle variant="h4" sx={{ mb: 1 }}>

--- a/frontend/pages/positions/[id]/index.tsx
+++ b/frontend/pages/positions/[id]/index.tsx
@@ -2,7 +2,7 @@ import
 {
   Avatar,
   Button,
-  Link, Paper, Stack, Typography, styled,
+  Link, Paper, Stack, Tooltip, Typography, styled,
 } from '@mui/material';
 import { useRouter } from 'next/router';
 import { useMemo } from 'react';
@@ -80,12 +80,14 @@ function PositionCard({
           alignItems="center"
         >
           <PositionTitle variant="h4">
-            <Link
-              href={routes.committeePage(position.committee.shortName)}
-              sx={{ mr: 2 }}
-            >
-              <CommitteeIcon name={position.committee.name} />
-            </Link>
+            <Tooltip title={position.committee.name}>
+              <Link
+                href={routes.committeePage(position.committee.shortName)}
+                sx={{ mr: 2 }}
+              >
+                <CommitteeIcon name={position.committee.name} />
+              </Link>
+            </Tooltip>
             {selectTranslation(i18n, position.name, position.nameEn)}
           </PositionTitle>
         </Stack>

--- a/frontend/public/locales/en/position.json
+++ b/frontend/public/locales/en/position.json
@@ -1,4 +1,4 @@
 {
-  "otherEmails": "These email adresser also go to this position",
+  "otherEmails": "These email adresses also go to this position",
   "primaryEmail": "Primary email"
 }

--- a/frontend/public/locales/en/position.json
+++ b/frontend/public/locales/en/position.json
@@ -1,0 +1,4 @@
+{
+  "otherEmails": "These emailadresser also go to this position",
+  "primaryEmail": "Primary email"
+}

--- a/frontend/public/locales/en/position.json
+++ b/frontend/public/locales/en/position.json
@@ -1,4 +1,4 @@
 {
-  "otherEmails": "These emailadresser also go to this position",
+  "otherEmails": "These email adresser also go to this position",
   "primaryEmail": "Primary email"
 }

--- a/frontend/public/locales/sv/position.json
+++ b/frontend/public/locales/sv/position.json
@@ -1,0 +1,4 @@
+{
+  "otherEmails": "Dessa e-poster går också till denna position",
+  "primaryEmail": "Primära e-post"
+}

--- a/frontend/public/locales/sv/position.json
+++ b/frontend/public/locales/sv/position.json
@@ -1,4 +1,4 @@
 {
   "otherEmails": "Dessa e-poster går också till denna position",
-  "primaryEmail": "Primära e-post"
+  "primaryEmail": "Primär e-post"
 }

--- a/frontend/routes.ts
+++ b/frontend/routes.ts
@@ -20,7 +20,7 @@ const routes = {
   createArticle: '/news/article/create',
   mandateByYear: (year) => `/mandates/${year}`,
   committees: '/committees',
-  committeePage: (committeeId) => `committees/${committeeId}`,
+  committeePage: (committeeId) => `/committees/${committeeId}`,
   position: (positionId) => `/positions/${positionId}`,
   events: '/events',
   passedEvents: '/events/passed',

--- a/frontend/routes.ts
+++ b/frontend/routes.ts
@@ -22,6 +22,7 @@ const routes = {
   committees: '/committees',
   committeePage: (committeeId) => `/committees/${committeeId}`,
   position: (positionId) => `/positions/${positionId}`,
+  editPosition: (positionId) => `/positions/${positionId}/edit`,
   events: '/events',
   passedEvents: '/events/passed',
   event: (eventId) => `/events/${eventId}`,

--- a/frontend/routes.ts
+++ b/frontend/routes.ts
@@ -21,6 +21,7 @@ const routes = {
   mandateByYear: (year) => `/mandates/${year}`,
   committees: '/committees',
   committeePage: (committeeId) => `committees/${committeeId}`,
+  position: (positionId) => `/positions/${positionId}`,
   events: '/events',
   passedEvents: '/events/passed',
   event: (eventId) => `/events/${eventId}`,

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This repository contains:  - Frontend for members.dsek.se  - Backend for api.dsek.se  - File server for files.dsek.se",
   "scripts": {
     "dev": "./dev.sh",
-    "lint": "eslint --ext .js,.jsx,.ts,.tsx frontend/",
+    "lint": "eslint --ext .js,.jsx,.ts,.tsx .",
     "lint-fix": "eslint --ext .js,.jsx,.ts,.tsx . --fix",
     "check-no-unresolved": "eslint --ext .js,.jsx,.ts,.tsx --rule 'import/no-unresolved: off' ."
   },


### PR DESCRIPTION
Also added:
- Links from profile page to positions page
- Re-did logic for mandate history. Now mandates from summer-summer are displayed correctly.
- Add possibility to edit positions (and emails)
- Only show "primary" email in most places, "all" emails are only shown on positions page