### PR TITLE
:bug: Fix issues with tag colors

### DIFF
--- a/frontend/components/Tags/CreateTag.tsx
+++ b/frontend/components/Tags/CreateTag.tsx
@@ -24,9 +24,9 @@ function CreateTag() {
   const onCreate = async () => {
     await createTag({
       variables: {
-        name,
-        nameEn,
-        color,
+        name: name?.trim(),
+        nameEn: nameEn?.trim(),
+        color: color?.trim(),
         isDefault,
       },
     }).then(() => {

--- a/frontend/components/Tags/EditTag.tsx
+++ b/frontend/components/Tags/EditTag.tsx
@@ -46,9 +46,9 @@ function EditTag({ id }: Props) {
     updateTag({
       variables: {
         id: data.tag.id,
-        name,
-        nameEn,
-        color,
+        name: name?.trim(),
+        nameEn: nameEn?.trim(),
+        color: color?.trim(),
         isDefault,
       },
     }).then(() => {

--- a/frontend/functions/colorFunctions.ts
+++ b/frontend/functions/colorFunctions.ts
@@ -177,17 +177,20 @@ const HSL_REGEX = /^hsla?\(\s*([+-]?(?=\.\d|\d)\d*(?:\.\d+)?(?:[eE][+-]?\d+)?(?:
 const RGB_REGEX = /^rgba?\(\s*(?!\d+(?:\.|\s*-?)\d+\.\d+)-?(?:\d*\.\d+|\d+)(%?)(?:(?:\s*,\s*-?(?:\d+|\d*\.\d+)\1){2}(?:\s*,\s*-?(?:\d+|\d*\.\d+)%?)?|(?:(?:\s*-?\d*\.\d+|\s*-\d+|\s+\d+){2}|(?:\s*-?(?:\d+|\d*\.\d+)%){2})(?:\s*\/\s*-?(?:\d+|\d*\.\d+)%?)?)\s*\)$/i;
 
 export function colorParser(color: string) {
-  if (HEX_REGEX.test(color ?? '')) {
+  if (color.length === 0) { // empty string
+    return 'rgb(255,255,255)';
+  }
+  if (HEX_REGEX.test(color)) {
     return hexToRgb(color);
   }
-  if (HSL_REGEX.test(color ?? '')) {
+  if (HSL_REGEX.test(color)) {
     return hslToRgb(color);
   }
-  if (RGB_REGEX.test(color ?? '')) {
+  if (RGB_REGEX.test(color)) {
     return color;
   }
-  if (colorMap.has(color?.toLowerCase() ?? '')) {
-    return colorMap.get(color);
+  if (colorMap.has(color?.toLowerCase())) {
+    return colorMap.get(color.toLowerCase());
   }
   return 'rgb(255,255,255)';
 }
@@ -232,7 +235,7 @@ export function colorAdjust(foreground: string, background: string) {
 }
 
 export function colorAppropiator(foreground: string | undefined, background: string) {
-  const fRGB = colorParser(foreground);
-  const bRGB = colorParser(background);
+  const fRGB = colorParser(foreground?.trim() ?? '');
+  const bRGB = colorParser(background?.trim() ?? '');
   return colorAdjust(fRGB, bRGB);
 }


### PR DESCRIPTION
We had two issues:
- If the color was the color of a CSS color but not lowercase, it caused the color to be undefined
- If the color had a trailing or preceding whitespace, it caused the color to be undefined

If the color was undefined it rendered as white, and occasionally even caused a crash as it tried to split undefined.

This is fixed now.