### PR TITLE
💄 Fix overflow issue on responsive grid

### DIFF
--- a/frontend/components/Committees/CommitteesList.tsx
+++ b/frontend/components/Committees/CommitteesList.tsx
@@ -18,7 +18,7 @@ function CommitteesList() {
   return (
     <Box sx={{
       display: 'grid',
-      gridTemplateColumns: 'repeat(auto-fill, minmax(18rem, 1fr))',
+      gridTemplateColumns: 'repeat(auto-fill, minmax(min(18rem, 100%), 1fr))',
       gap: 2,
     }}
     >

--- a/frontend/components/Documents/Meeting.tsx
+++ b/frontend/components/Documents/Meeting.tsx
@@ -20,7 +20,7 @@ export default function MeetingComponent({ meeting }: { meeting: Meeting }) {
       <h2 style={{ margin: 0 }}>{meeting.title}</h2>
       <Box sx={{
         display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(min(250px, 100%), 1fr))',
         gap: 2,
       }}
       >

--- a/frontend/components/Positions/index.tsx
+++ b/frontend/components/Positions/index.tsx
@@ -36,7 +36,7 @@ function Positions({ shortName }: { shortName: string }) {
       && <MarkdownPage name={isBoard ? 'styr' : `${positions[0].committee.shortName}`} />}
       <Stack sx={{
         display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fill, minmax(450px, 1fr))',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(min(450px, 100%), 1fr))',
         gap: 2,
       }}
       >

--- a/frontend/pages/booking/index.tsx
+++ b/frontend/pages/booking/index.tsx
@@ -93,7 +93,7 @@ export default function BookingPage() {
       <PageHeader>{t('booking:colorcode')}</PageHeader>
       <Box sx={{
         display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fill, minmax(400px, 1fr))',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(min(400px, 100%), 1fr))',
         gap: 1,
       }}
       >

--- a/frontend/pages/nolla/faq.tsx
+++ b/frontend/pages/nolla/faq.tsx
@@ -7,7 +7,7 @@ import genGetProps from '~/functions/genGetServerSideProps';
 
 function FAQ() {
   return (
-    <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(350px, 1fr))', gap: [2, 4, 8] }}>
+    <Box sx={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(min(350px, 100%), 1fr))', gap: [2, 4, 8] }}>
       <MasonryCard sx={{ '& > *:first-child': { height: '100%' } }}>
         <Typography variant="h5" fontWeight={500}>
           Vad är en phadder?

--- a/frontend/pages/positions/[id]/index.tsx
+++ b/frontend/pages/positions/[id]/index.tsx
@@ -152,7 +152,7 @@ function PositionCard({
                 maxWidth: '100%',
                 marginTop: '1rem',
                 display: 'grid',
-                gridTemplateColumns: 'repeat(auto-fill, minmax(200px, 1fr))',
+                gridTemplateColumns: 'repeat(auto-fill, minmax(min(200px, 100%), 1fr))',
                 rowGap: 2,
                 columnGap: 1,
               }}


### PR DESCRIPTION
Updates the gridTemplateColumns property in the relevant components, fixing an issue where content was overflowing the x-axis on smaller screens.

**Before**
<img width="379" alt="image" src="https://github.com/Dsek-LTH/member-page/assets/63123731/30515bc1-13e6-402b-8e95-f0e2820dbc48">

**After**
<img width="379" alt="image" src="https://github.com/Dsek-LTH/member-page/assets/63123731/c4823bd3-7ff4-4075-a9b4-eba8ee1cb34f">